### PR TITLE
fix(decompile) restore write output to file

### DIFF
--- a/heimdall/src/decompile/output.rs
+++ b/heimdall/src/decompile/output.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use heimdall_common::io::{logging::{TraceFactory, Logger}, file::{short_path, write_file}};
+use heimdall_common::io::{logging::{TraceFactory, Logger}, file::{short_path, write_file, write_lines_to_file}};
 use indicatif::ProgressBar;
 
 use super::{DecompilerArgs, util::Function, constants::DECOMPILED_SOURCE_HEADER, postprocess::postprocess};
@@ -397,10 +397,10 @@ pub fn build_output(
         
     }
 
-    // write_lines_to_file(
-    //     &decompiled_output_path,
-    //     decompiled_output
-    // );
-    //
-    // logger.info(&format!("wrote decompiled solidity to '{}' .", decompiled_output_path).to_string());
+    write_lines_to_file(
+        &decompiled_output_path,
+        decompiled_output
+    );
+    
+    logger.info(&format!("wrote decompiled solidity to '{}' .", decompiled_output_path).to_string());
 }


### PR DESCRIPTION
Decompile module didn't write output to the sol file:
```
$ heimdall decompile -r https://rpc.ankr.com/eth 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D -o 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
success: disassembled 21943 bytes successfully.
$ ls 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D/
abi.json          bytecode.evm      disassembled.asm
```

Fixed:
```
$ cargo run --  decompile -r https://rpc.ankr.com/eth 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D -o 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/heimdall decompile -r 'https://rpc.ankr.com/eth' 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D -o 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D`
success: disassembled 21943 bytes successfully.
$ ls 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D/
abi.json          bytecode.evm      decompiled.sol    disassembled.asm
```