### PR TITLE
fix(decompile): use 32 byte hash for events to reduce collisions

### DIFF
--- a/common/src/ether/signatures.rs
+++ b/common/src/ether/signatures.rs
@@ -140,7 +140,7 @@ pub fn resolve_error_signature(signature: &String) -> Option<Vec<ResolvedError>>
 pub fn resolve_event_signature(signature: &String) -> Option<Vec<ResolvedLog>> {
 
     // get function possibilities from 4byte
-    let signatures = match get_json_from_url(format!("https://sig.eth.samczsun.com/api/v1/signatures?all=true&function=0x{}", &signature)) {
+    let signatures = match get_json_from_url(format!("https://sig.eth.samczsun.com/api/v1/signatures?all=true&event=0x{}", &signature)) {
         Some(signatures) => signatures,
         None => return None
     };
@@ -148,10 +148,10 @@ pub fn resolve_event_signature(signature: &String) -> Option<Vec<ResolvedLog>> {
     // convert the serde value into a vec of possible functions
     // AAAHAHHHHHH IM MATCHING
     let results = match signatures.get("result") {
-        Some(result) => match result.get("function") {
-            Some(function) => match function.get(format!("0x{signature}")) {
-                Some(functions) => match functions.as_array() {
-                    Some(functions) => functions.to_vec(),
+        Some(result) => match result.get("event") {
+            Some(event) => match event.get(format!("0x{signature}")) {
+                Some(events) => match events.as_array() {
+                    Some(events) => events.to_vec(),
                     None => return None
                 },
                 None => return None

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -357,7 +357,7 @@ pub fn decompile(args: DecompilerArgs) {
         }
 
         if !args.skip_resolving {
-            
+
             let resolved_functions = match resolved_selectors.get(&selector) {
                 Some(func) => func.clone(),
                 None => {
@@ -480,8 +480,8 @@ pub fn decompile(args: DecompilerArgs) {
             // resolve custom event signatures
             resolved_counter = 0;
             for (event_selector, (_, raw_event)) in analyzed_function.events.clone() {
-                decompilation_progress.set_message(format!("resolving event 0x{}", &event_selector.get(0..8).unwrap().to_string()));
-                let resolved_event_selectors = resolve_event_signature(&event_selector.get(0..8).unwrap().to_string());
+                decompilation_progress.set_message(format!("resolving event 0x{}", &event_selector.get(0..64).unwrap().to_string()));
+                let resolved_event_selectors = resolve_event_signature(&event_selector.get(0..64).unwrap().to_string());
 
                 // only continue if we have matches
                 match resolved_event_selectors {
@@ -507,7 +507,7 @@ pub fn decompile(args: DecompilerArgs) {
                                 std::process::exit(1)
                             }
                         };
-                        
+
                         resolved_counter += 1;
                         analyzed_function.events.insert(event_selector, (Some(selected_match.clone()), raw_event));
                     },

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -480,7 +480,7 @@ pub fn decompile(args: DecompilerArgs) {
             // resolve custom event signatures
             resolved_counter = 0;
             for (event_selector, (_, raw_event)) in analyzed_function.events.clone() {
-                decompilation_progress.set_message(format!("resolving event 0x{}", &event_selector.get(0..64).unwrap().to_string()));
+                decompilation_progress.set_message(format!("resolving event 0x{}", &event_selector.get(0..8).unwrap().to_string()));
                 let resolved_event_selectors = resolve_event_signature(&event_selector.get(0..64).unwrap().to_string());
 
                 // only continue if we have matches


### PR DESCRIPTION
#### Description
This PR reduces the number of collisions when decompiling contracts that contain events. 

#### Example

The `Transfer(address,address,uint256)` event on USDC implementation contract (`0xa2327a938febf5fec13bacfb16ae10ecbc4cbdcf`) currently results in a collision. 

The current resolution request is:
https://sig.eth.samczsun.com/api/v1/signatures?all=true&function=0xddf252ad

With this update, we use the full 32 byte hash and the event api, to reduce the likelihood of collisions.
https://sig.eth.samczsun.com/api/v1/signatures?all=true&event=0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef



