### PR TITLE
:wrench: fix: loop detection to take into account memory and storage

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -23,6 +23,12 @@ lazy_static! {
     // The following regex is used to find type castings
     pub static ref TYPE_CAST_REGEX: Regex = Regex::new(r"(address\(|string\(|bool\(|bytes(\d*)\(|uint(\d*)\(|int(\d*)\()").unwrap();
 
-    // The following regex is used to find memory accesses
+    // The following regex is used to find memory length accesses
     pub static ref MEMLEN_REGEX: Regex = Regex::new(r"memory\[memory\[[0-9x]*\]\]").unwrap();
+
+    // The following regex is used to find memory accesses
+    pub static ref MEMORY_REGEX: Regex = Regex::new(r"memory\[\(?[0-9x]*\]").unwrap();
+
+    // The following regex is used to find storage accesses
+    pub static ref STORAGE_REGEX: Regex = Regex::new(r"storage\[\(?[0-9x]*\]").unwrap();
 }

--- a/common/src/ether/evm/vm.rs
+++ b/common/src/ether/evm/vm.rs
@@ -1609,6 +1609,8 @@ impl VM {
     pub fn step(&mut self) -> State {
         let instruction = self._step();
 
+        //println!("{}({:?})", instruction.clone().opcode_details.unwrap().name, instruction.inputs);
+
         State {
             last_instruction: instruction,
             gas_used: self.gas_used,

--- a/heimdall/src/decompile/analyze.rs
+++ b/heimdall/src/decompile/analyze.rs
@@ -36,10 +36,6 @@ impl VMTrace {
         let mut jumped_conditional: Option<String> = None;
         let mut revert_conditional: Option<String> = None;
 
-        // if self.loop_detected {
-        //     function.logic.push("// loop detected".to_owned());
-        // }
-
         // perform analysis on the operations of the current VMTrace branch
         for operation in &self.operations {
             let instruction = operation.last_instruction.clone();

--- a/heimdall/src/decompile/util.rs
+++ b/heimdall/src/decompile/util.rs
@@ -327,6 +327,17 @@ pub fn recursive_map(
                 state.last_instruction.inputs[1] == U256::from(0)
             );
 
+            // if the stack has over 16 items of the same source, it's probably a loop
+            if vm.stack.size() > 16 {
+               for frame in vm.stack.stack.iter() {
+                    let solidified_frame_source = frame.operation.solidify();
+                    if vm.stack.stack.iter().filter(|f| f.operation.solidify() == solidified_frame_source).count() >= 16 {
+                        vm_trace.loop_detected = true;
+                        return vm_trace;
+                    }
+               }
+            }
+
             // break out of loops
             match handled_jumps.get(&jump_frame) {
                 Some(historical_stacks) => {
@@ -339,6 +350,16 @@ pub fn recursive_map(
                                 stack_diff.push(frame);
                             }
                         }
+
+                        // println!("\nStack: ");
+                        // for (i, frame) in stack.iter().enumerate() {
+                        //     println!("  {} {} {}", i, frame.value, frame.operation.solidify());
+                        // }
+
+                        // println!("Stack Diff: ");
+                        // for (i, frame) in stack_diff.iter().enumerate() {
+                        //     println!("  {} {} {}", i, frame.value, frame.operation.solidify());
+                        // }
 
                         if !stack_diff.is_empty() {
                     

--- a/heimdall/src/decompile/util.rs
+++ b/heimdall/src/decompile/util.rs
@@ -12,7 +12,7 @@ use heimdall_common::{
             opcodes::WrappedOpcode,
             vm::{State, VM}, stack::{StackFrame}
         }, signatures::{ResolvedFunction, ResolvedError, ResolvedLog},
-    },
+    }, constants::{MEMORY_REGEX, STORAGE_REGEX},
 };
 
 #[derive(Clone, Debug)]
@@ -330,7 +330,6 @@ pub fn recursive_map(
             // break out of loops
             match handled_jumps.get(&jump_frame) {
                 Some(historical_stacks) => {
-
                     if historical_stacks.iter().any(|stack| {
 
                         // compare stacks
@@ -345,7 +344,39 @@ pub fn recursive_map(
                     
                             // check if all stack diff values are in the jump condition
                             let jump_condition = state.last_instruction.input_operations[1].solidify();
-                            return stack_diff.iter().any(|frame| jump_condition.contains(&frame.operation.solidify()))
+                            
+                            // if the stack diff is within the jump condition, its likely that we are in a loop
+                            if stack_diff.iter().any(|frame| jump_condition.contains(&frame.operation.solidify())) {
+                                return true;
+                            }
+                            
+                            // if a memory access in the jump condition is modified by the stack diff, its likely that we are in a loop
+                            let mut memory_accesses = MEMORY_REGEX.find_iter(&jump_condition);
+                            if stack_diff.iter().any(|frame| {
+                                return memory_accesses.any(|_match| {
+                                    if _match.is_err() { return false; }
+                                    let memory_access = _match.unwrap();
+                                    let slice = &jump_condition[memory_access.start()..memory_access.end()];
+                                    return frame.operation.solidify().contains(slice);
+                                })
+                            }) {
+                                return true;
+                            }
+
+                            // if a storage access in the jump condition is modified by the stack diff, its likely that we are in a loop
+                            let mut storage_accesses = STORAGE_REGEX.find_iter(&jump_condition);
+                            if stack_diff.iter().any(|frame| {
+                                return storage_accesses.any(|_match| {
+                                    if _match.is_err() { return false; }
+                                    let storage_access = _match.unwrap();
+                                    let slice = &jump_condition[storage_access.start()..storage_access.end()];
+                                    return frame.operation.solidify().contains(slice);
+                                })
+                            }) {
+                                return true;
+                            }
+
+                            return false
                         }
                         else {
                             return true
@@ -355,7 +386,6 @@ pub fn recursive_map(
                         return vm_trace;
                     }
                     else {
-
                         // this key exists, but the stack is different, so the jump is new
                         let historical_stacks: &mut Vec<VecDeque<StackFrame>> = &mut historical_stacks.clone();
                         historical_stacks.push(vm.stack.stack.clone());


### PR DESCRIPTION
Memory and storage accesses will also be taken into account when checking if the stack diff of a `JUMPI` modifies a given JUMPI condition, indicating a loop.