### PR TITLE
Output full event signatures on unresolved ABI

### DIFF
--- a/heimdall/src/decompile/output.rs
+++ b/heimdall/src/decompile/output.rs
@@ -227,8 +227,8 @@ pub fn build_output(
                     }
 
                     abi.push(
-                        ABIStructure::Error(
-                            ErrorABI {
+                        ABIStructure::Event(
+                            EventABI {
                                 type_: "event".to_string(),
                                 name: resolved_event.name.clone(),
                                 inputs: inputs,
@@ -238,8 +238,8 @@ pub fn build_output(
                 },
                 None => {
                     abi.push(
-                        ABIStructure::Error(
-                            ErrorABI {
+                        ABIStructure::Event(
+                            EventABI {
                                 type_: "event".to_string(),
                                 name: format!("Event_{}", event_selector),
                                 inputs: Vec::new(),

--- a/heimdall/src/decompile/output.rs
+++ b/heimdall/src/decompile/output.rs
@@ -241,7 +241,7 @@ pub fn build_output(
                         ABIStructure::Error(
                             ErrorABI {
                                 type_: "event".to_string(),
-                                name: format!("Event_{}", event_selector.get(0..8).unwrap()),
+                                name: format!("Event_{}", event_selector),
                                 inputs: Vec::new(),
                             }
                         )


### PR DESCRIPTION
It would be useful to output the full signature hash of events when the resolution is skipped. Currently, it only writes the first 8 bytes, but event signatures are not "compressed" like function ones; they are always used as a whole.

For example, instead of having:

```
Event_ddf252ad
```

it should output:

```
Event_ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
```

Having the full signature is useful, it can be used to retrieve logs or perform reverse hashing afterward.

I also fixed the use of the struct, it was using the ErrorABI struct instead of the EventABI one.