### PR TITLE
:wrench: fix: Get all the results from openchain

### DIFF
--- a/common/src/ether/signatures.rs
+++ b/common/src/ether/signatures.rs
@@ -110,7 +110,13 @@ pub fn resolve_error_signature(signature: &String) -> Option<Vec<ResolvedError>>
     };
 
     // get function possibilities from 4byte
-    let signatures = match get_json_from_url(format!("https://api.openchain.xyz/signature-database/v1/lookup?function=0x{}", &signature), 3) {
+    let signatures = match get_json_from_url(
+        format!(
+            "https://api.openchain.xyz/signature-database/v1/lookup?filter=false&function=0x{}",
+            &signature
+        ),
+        3,
+    ) {
         Some(signatures) => signatures,
         None => return None
     };


### PR DESCRIPTION
When fetching the signature from `openchain.xyz`, by default the results are filter.
For example https://api.openchain.xyz/signature-database/v1/lookup?filter=false&function=0x06fdde03 returns:
```
{"ok":true,"result":{"event":{},"function":{"0x06fdde03":[{"name":"name()","filtered":false},{"name":"message_hour(uint256,int8,uint16,bytes32)","filtered":true}]}}}
```
https://api.openchain.xyz/signature-database/v1/lookup?function=0x06fdde03 returns:
```
{"ok":true,"result":{"event":{},"function":{"0x06fdde03":[{"name":"name()","filtered":false}]}}}
```