### PR TITLE
fix: default signature resolution

### DIFF
--- a/common/src/ether/signatures.rs
+++ b/common/src/ether/signatures.rs
@@ -212,3 +212,18 @@ pub fn resolve_event_signature(signature: &String) -> Option<Vec<ResolvedLog>> {
         _ => Some(signature_list),
     }
 }
+
+pub fn score_signature(signature: &String) -> u32 {
+
+    // the score starts at 1000
+    let mut score = 1000;
+
+    // remove the length of the signature from the score
+    // this will prioritize shorter signatures, which are typically less spammy
+    score -= signature.len() as u32;
+
+    // prioritize signatures with less numbers
+    score -= (signature.matches(|c: char| c.is_numeric()).count() as u32) * 3;
+
+    score
+}

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -444,7 +444,7 @@ pub fn decompile(args: DecompilerArgs) {
                 }
             };
 
-            let matched_resolved_functions =
+            let mut matched_resolved_functions =
                 match_parameters(resolved_functions, &analyzed_function);
 
             trace.br(func_analysis_trace);
@@ -456,6 +456,14 @@ pub fn decompile(args: DecompilerArgs) {
                 );
             } else {
                 let mut selected_function_index: u8 = 0;
+
+                // sort matches by signature using score heuristic from `score_signature`
+                matched_resolved_functions.sort_by(|a, b| {
+                    let a_score = score_signature(&a.signature);
+                    let b_score = score_signature(&b.signature);
+                    b_score.cmp(&a_score)
+                });
+
                 if matched_resolved_functions.len() > 1 {
                     decompilation_progress.suspend(|| {
                         selected_function_index = logger.option(
@@ -465,7 +473,7 @@ pub fn decompile(args: DecompilerArgs) {
                                 .iter()
                                 .map(|x| x.signature.clone())
                                 .collect(),
-                            Some(0 as u8),
+                            Some(0u8),
                             args.default,
                         );
                     });
@@ -507,8 +515,16 @@ pub fn decompile(args: DecompilerArgs) {
                 let resolved_error_selectors = resolve_error_signature(&error_selector_str);
 
                 // only continue if we have matches
-                if let Some(resolved_error_selectors) = resolved_error_selectors {
+                if let Some(mut resolved_error_selectors) = resolved_error_selectors {
                     let mut selected_error_index: u8 = 0;
+
+                    // sort matches by signature using score heuristic from `score_signature`
+                    resolved_error_selectors.sort_by(|a, b| {
+                        let a_score = score_signature(&a.signature);
+                        let b_score = score_signature(&b.signature);
+                        b_score.cmp(&a_score)
+                    });
+
                     if resolved_error_selectors.len() > 1 {
                         decompilation_progress.suspend(|| {
                             selected_error_index = logger.option(
@@ -518,7 +534,7 @@ pub fn decompile(args: DecompilerArgs) {
                                     .iter()
                                     .map(|x| x.signature.clone())
                                     .collect(),
-                                Some((resolved_error_selectors.len() - 1) as u8),
+                                Some(0u8),
                                 args.default,
                             );
                         });
@@ -564,8 +580,16 @@ pub fn decompile(args: DecompilerArgs) {
                 let resolved_event_selectors = resolve_event_signature(&event_selector_str);
 
                 // only continue if we have matches
-                if let Some(resolved_event_selectors) = resolved_event_selectors {
+                if let Some(mut resolved_event_selectors) = resolved_event_selectors {
                     let mut selected_event_index: u8 = 0;
+
+                    // sort matches by signature using score heuristic from `score_signature`
+                    resolved_event_selectors.sort_by(|a, b| {
+                        let a_score = score_signature(&a.signature);
+                        let b_score = score_signature(&b.signature);
+                        b_score.cmp(&a_score)
+                    });
+
                     if resolved_event_selectors.len() > 1 {
                         decompilation_progress.suspend(|| {
                             selected_event_index = logger.option(
@@ -575,7 +599,7 @@ pub fn decompile(args: DecompilerArgs) {
                                     .iter()
                                     .map(|x| x.signature.clone())
                                     .collect(),
-                                Some((resolved_event_selectors.len() - 1) as u8),
+                                Some(0u8),
                                 args.default,
                             );
                         });

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -465,7 +465,7 @@ pub fn decompile(args: DecompilerArgs) {
                                 .iter()
                                 .map(|x| x.signature.clone())
                                 .collect(),
-                            Some((matched_resolved_functions.len() - 1) as u8),
+                            Some(0 as u8),
                             args.default,
                         );
                     });


### PR DESCRIPTION
I noticed that, in case of multiple reverse hashes found, it always proposes the last option available. 
This is often not the most used signature, in most cases it's the first one. It would be better to select the first one as default.
I modified the code to put as default the one with index 0.
For example:
<img width="580" alt="Screenshot 2023-06-01 at 11 10 46" src="https://github.com/Jon-Becker/heimdall-rs/assets/17318562/6c4687ce-b997-4000-b5dd-aba3c082a7e0">
