### PR TITLE
:wrench: fix: replace newline characters on the bytecode

### DIFF
--- a/common/src/ether/evm/ext/disassemble.rs
+++ b/common/src/ether/evm/ext/disassemble.rs
@@ -80,7 +80,7 @@ pub fn disassemble(args: DisassemblerArgs) -> String {
         // We are disassembling a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                let _contents = contents.replace("\n", "");
+                let _contents = contents.replace('\n', "");
                 if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
                     _contents
                 } else {

--- a/common/src/ether/evm/ext/disassemble.rs
+++ b/common/src/ether/evm/ext/disassemble.rs
@@ -80,8 +80,9 @@ pub fn disassemble(args: DisassemblerArgs) -> String {
         // We are disassembling a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                if BYTECODE_REGEX.is_match(&contents).unwrap() && contents.len() % 2 == 0 {
-                    contents
+                let _contents = contents.replace("\n", "");
+                if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
+                    _contents
                 } else {
                     logger
                         .error(&format!("file '{}' doesn't contain valid bytecode.", &args.target));

--- a/heimdall/src/cfg/mod.rs
+++ b/heimdall/src/cfg/mod.rs
@@ -122,7 +122,7 @@ pub fn cfg(args: CFGArgs) {
         // We are analyzing a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                let _contents = contents.replace("\n", "");
+                let _contents = contents.replace('\n', "");
                 if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
                     _contents.replacen("0x", "", 1)
                 } else {

--- a/heimdall/src/cfg/mod.rs
+++ b/heimdall/src/cfg/mod.rs
@@ -122,8 +122,9 @@ pub fn cfg(args: CFGArgs) {
         // We are analyzing a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                if BYTECODE_REGEX.is_match(&contents).unwrap() && contents.len() % 2 == 0 {
-                    contents.replacen("0x", "", 1)
+                let _contents = contents.replace("\n", "");
+                if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
+                    _contents.replacen("0x", "", 1)
                 } else {
                     logger
                         .error(&format!("file '{}' doesn't contain valid bytecode.", &args.target));

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -145,8 +145,9 @@ pub fn decompile(args: DecompilerArgs) {
         // We are decompiling a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                if BYTECODE_REGEX.is_match(&contents).unwrap() && contents.len() % 2 == 0 {
-                    contents.replacen("0x", "", 1)
+                let _contents = contents.replace("\n", "");
+                if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
+                    _contents.replacen("0x", "", 1)
                 } else {
                     logger
                         .error(&format!("file '{}' doesn't contain valid bytecode.", &args.target));

--- a/heimdall/src/decompile/mod.rs
+++ b/heimdall/src/decompile/mod.rs
@@ -145,7 +145,7 @@ pub fn decompile(args: DecompilerArgs) {
         // We are decompiling a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
             Ok(contents) => {
-                let _contents = contents.replace("\n", "");
+                let _contents = contents.replace('\n', "");
                 if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
                     _contents.replacen("0x", "", 1)
                 } else {

--- a/heimdall/src/snapshot/mod.rs
+++ b/heimdall/src/snapshot/mod.rs
@@ -134,9 +134,10 @@ pub fn snapshot(args: SnapshotArgs) {
 
         // We are snapshotting a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
+            let _contents = contents.replace("\n", "");
             Ok(contents) => {
-                if BYTECODE_REGEX.is_match(&contents).unwrap() && contents.len() % 2 == 0 {
-                    contents.replacen("0x", "", 1)
+                if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
+                    _contents.replacen("0x", "", 1)
                 } else {
                     logger
                         .error(&format!("file '{}' doesn't contain valid bytecode.", &args.target));

--- a/heimdall/src/snapshot/mod.rs
+++ b/heimdall/src/snapshot/mod.rs
@@ -134,8 +134,8 @@ pub fn snapshot(args: SnapshotArgs) {
 
         // We are snapshotting a file, so we need to read the bytecode from the file.
         contract_bytecode = match fs::read_to_string(&args.target) {
-            let _contents = contents.replace("\n", "");
             Ok(contents) => {
+                let _contents = contents.replace('\n', "");
                 if BYTECODE_REGEX.is_match(&_contents).unwrap() && _contents.len() % 2 == 0 {
                     _contents.replacen("0x", "", 1)
                 } else {


### PR DESCRIPTION
SSIA. Support the bytecode file which has a new line at the end of the file. (e.g., vim / cat saved files)