### PR TITLE
feat(snapshot): sort selectors ascending

### DIFF
--- a/core/src/snapshot/util/table.rs
+++ b/core/src/snapshot/util/table.rs
@@ -22,8 +22,11 @@ pub fn build_rows(state: &mut State, max_row_height: usize) -> Vec<Row<'static>>
         false => snapshots.len() - num_items..snapshots.len(),
     };
 
+    let mut sorted_snapshots = snapshots[indices].to_vec();
+    sorted_snapshots.sort_by(|a, b| a.selector.cmp(&b.selector));
+
     // slice storage_iter
-    for (i, snapshot) in snapshots[indices].iter().enumerate() {
+    for (i, snapshot) in sorted_snapshots.iter().enumerate() {
         rows.push(
             Row::new(vec![Cell::from(format!(" 0x{} ", snapshot.selector))])
                 .style(if snapshots.len() - state.function_index < num_items {
@@ -63,3 +66,4 @@ pub fn build_rows(state: &mut State, max_row_height: usize) -> Vec<Row<'static>>
 
     rows
 }
+

--- a/core/src/snapshot/util/table.rs
+++ b/core/src/snapshot/util/table.rs
@@ -66,4 +66,3 @@ pub fn build_rows(state: &mut State, max_row_height: usize) -> Vec<Row<'static>>
 
     rows
 }
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This PR fixes Issue #178 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- I first create a vector sorted_snapshots from the relevant slice of snapshots.
- Then, I sort sorted_snapshots in place using sort_by.
- Finally, I iterate over sorted_snapshots to build the rows.

I could have implement `Ord` trait for `Snapshot` , but it seemed an overkill to me, as this is the only place in the codebase so far that requires such ordering. Once new sorting cases appears, the trait approach must be more suitable.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
_Demo_
![image](https://github.com/Jon-Becker/heimdall-rs/assets/29215044/10ca3d96-d89f-4b27-af32-958712be4f9a)

