### PR TITLE
perf(cli): use `less` for `--output print` handling

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, io::Write};
 
 use heimdall_common::{constants::ADDRESS_REGEX, ether::rpc};
 
@@ -29,6 +29,18 @@ pub async fn build_output_path(
 
     // output is specified, return the path
     Ok(format!("{}/{}", output, filename))
+}
+
+/// pass the input to the `less` command
+pub async fn print_with_less(input: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut child =
+        std::process::Command::new("less").stdin(std::process::Stdio::piped()).spawn()?;
+
+    let stdin = child.stdin.as_mut().unwrap();
+    stdin.write_all(input.as_bytes())?;
+
+    child.wait()?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/less
+++ b/less
@@ -1,0 +1,1 @@
+aasajhqbsfkjhbsadfkjbsdfjkas

--- a/less
+++ b/less
@@ -1,1 +1,0 @@
-aasajhqbsfkjhbsadfkjbsdfjkas


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Long outputs (such as `heimdall disassemble 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 -d --output print`) get truncated because of their line count.

## Solution

Use `less` to display these outputs.
