### PR TITLE
fix(symbolic-execution): add growth loop-detection heuristic

### DIFF
--- a/common/src/ether/evm/ext/exec/jump_frame.rs
+++ b/common/src/ether/evm/ext/exec/jump_frame.rs
@@ -1,0 +1,15 @@
+use ethers::types::U256;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct JumpFrame {
+    pub pc: u128,
+    pub jumpdest: U256,
+    pub stack_depth: usize,
+    pub jump_taken: bool,
+}
+
+impl JumpFrame {
+    pub fn new(pc: u128, jumpdest: U256, stack_depth: usize, jump_taken: bool) -> Self {
+        Self { pc, jumpdest, stack_depth, jump_taken }
+    }
+}

--- a/common/src/ether/evm/ext/exec/util.rs
+++ b/common/src/ether/evm/ext/exec/util.rs
@@ -144,8 +144,11 @@ pub fn jump_condition_historical_diffs_approximately_equal(
         );
     }
 
-    // check if all stack diffs are exactly length 1
-    if !stack_diffs.iter().all(|diff| diff.len() == 1) {
+    // get stack length / 10, rounded up as threshold
+    let threshold = (stack.size() as f64 / 10f64).ceil() as usize;
+
+    // check if all stack diffs are similar
+    if !stack_diffs.iter().all(|diff| diff.len() <= threshold) {
         return false;
     }
 

--- a/common/src/utils/range_map.rs
+++ b/common/src/utils/range_map.rs
@@ -103,11 +103,7 @@ impl RangeMap {
     }
 
     fn affected_ranges(&self, range: Range<usize>) -> Vec<Range<usize>> {
-        self.0
-            .keys()
-            .filter(|incumbent| Self::range_collides(&range, *incumbent))
-            .cloned()
-            .collect()
+        self.0.keys().filter(|incumbent| Self::range_collides(&range, incumbent)).cloned().collect()
     }
 
     fn range_collides(incoming: &Range<usize>, incumbent: &Range<usize>) -> bool {

--- a/core/tests/test_decompile.rs
+++ b/core/tests/test_decompile.rs
@@ -296,6 +296,10 @@ mod integration_tests {
             "0xd1d2Eb1B1e90B638588728b4130137D262C87cae",
             "0x95e05e2Abbd26943874ac000D87C3D9e115B543c",
             "0x00000000A991C429eE2Ec6df19d40fe0c80088B8",
+            "0x737673b5e0a3c68adf4c1a87bca5623cfc537ec3",
+            "0x940259178FbF021e625510919BC2FF0B944E5613",
+            "0xff612db0583be8d5498731e4e32bc12e08fa6292",
+            "0xd5FEa30Ed719693Ec8848Dc7501b582F5de6a5BB",
         ];
 
         // define flag checks


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Adds symbolic execution heuristic `jump_stack_depth_less_than_max_stack_depth` which ensures we only handle growing stacks. I.e, if the current `stack_depth` for the `JumpFrame` is 30, but we have `max_stack_depth` of 72, we don't need to cover this as it will likely grow forever (and cause hanging).

Fixes #167 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
