### PR TITLE
fix(symbolic-exec): break out of infinite `JUMP` loops

### DIFF
--- a/common/src/ether/evm/ext/exec/util.rs
+++ b/common/src/ether/evm/ext/exec/util.rs
@@ -22,6 +22,18 @@ pub fn stack_diff(a: &Stack, b: &Stack) -> Vec<StackFrame> {
     diff
 }
 
+/// Check if the given stack contains too many items to feasibly
+/// reach the bottom of the stack without being a loop.
+pub fn stack_contains_too_many_items(stack: &Stack) -> bool {
+    if stack.size() > 320 {
+        // 320 is an arbitrary number, i picked it randomly :D
+        debug_max!("jump matches loop-detection heuristic: 'stack_contains_too_many_items'",);
+        return true
+    }
+
+    false
+}
+
 /// Check if the given stack contains too many of the same item.
 /// If the stack contains more than 16 of the same item (with the same sources), it is considered a
 /// loop.
@@ -123,10 +135,7 @@ pub fn jump_condition_contains_mutated_storage_access(
 }
 
 /// check if all stack diffs for all historical stacks are exactly length 1, and the same
-pub fn jump_condition_historical_diffs_approximately_equal(
-    stack: &Stack,
-    historical_stacks: &[Stack],
-) -> bool {
+pub fn historical_diffs_approximately_equal(stack: &Stack, historical_stacks: &[Stack]) -> bool {
     // break if historical_stacks.len() < 4
     // this is an arbitrary number, i picked it randomly :D
     if historical_stacks.len() < 4 {

--- a/core/tests/test_decompile.rs
+++ b/core/tests/test_decompile.rs
@@ -301,6 +301,7 @@ mod integration_tests {
             "0xff612db0583be8d5498731e4e32bc12e08fa6292",
             "0xd5FEa30Ed719693Ec8848Dc7501b582F5de6a5BB",
             "0x4C727a07246A70862e45B2E58fcd82c0eD5Eda85",
+            "0x9baa53dD2aB408D9135e549831C06E5c6407bF1d",
         ];
 
         // define flag checks


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This PR will allow symbolic execution to break out of infinite `JUMP` loops (not just `JUMPI`).

Closes #253 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
