### PR TITLE
fix(vm): range underflow error

### DIFF
--- a/common/src/utils/range_map.rs
+++ b/common/src/utils/range_map.rs
@@ -2,13 +2,6 @@ use std::{collections::HashMap, ops::Range};
 
 use crate::ether::evm::core::opcodes::WrappedOpcode;
 
-#[derive(Copy, Clone, Debug)]
-enum CollisionKind {
-    Deletion,
-    Splitting,
-    Shortening,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RangeMap(pub HashMap<Range<usize>, WrappedOpcode>);
 
@@ -39,64 +32,48 @@ impl RangeMap {
             self.0.insert(range, opcode);
         } else {
             incumbents.iter().for_each(|incumbent| {
-                match Self::classify_collision(&range, incumbent) {
-                    CollisionKind::Deletion => {
+                if incumbent.end < range.start {}
+                else if incumbent.start > range.end {}
+                else {
+                    // Case 1: overlapping
+                    if range.start <= incumbent.start && range.end >= incumbent.end {
+                        // newInterval completely covers incumbent
+                        // remove the existing interval
                         self.0.remove(incumbent);
                     }
-                    CollisionKind::Splitting => {
-                        let left: Range<usize> =
-                            Range { start: incumbent.start, end: range.start - 1 };
-                        let right: Range<usize> =
-                            Range { start: range.end + 1, end: incumbent.end };
-                        let old_opcode: WrappedOpcode = self.0.get(incumbent).expect("").clone();
-
+                    // Case 2: shortening
+                    else if range.start <= incumbent.start && range.end < incumbent.end {
+                        let remainder: Range<usize> = Range { start: range.end + 1, end: incumbent.end };
+                        let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
+                        self.0.remove(incumbent);
+                        self.0.insert(remainder, old_opcode);
+                        
+                    } else if range.start > incumbent.start && range.end >= incumbent.end {
+                        let remainder: Range<usize> = Range { start: incumbent.start, end: range.start - 1 };
+                        let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
+                        self.0.remove(incumbent);
+                        self.0.insert(remainder, old_opcode);
+                        
+                    } 
+                    // Case 3: splitting
+                    else if range.start > incumbent.start && range.end < incumbent.end {    
+                        let left: Range<usize> = Range { start: incumbent.start, end: range.start - 1 };
+                        let right: Range<usize> = Range { start: range.end + 1, end: incumbent.end };
+                        let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
                         self.0.remove(incumbent);
                         self.0.insert(left, old_opcode.clone());
                         self.0.insert(right, old_opcode.clone());
-                    }
-                    CollisionKind::Shortening => {
-                        let needs_right_shortening =
-                            |incoming: &Range<usize>, incumbent: &Range<usize>| {
-                                incoming.start >= incumbent.start
-                            };
-
-                        if needs_right_shortening(&range, incumbent) {
-                            let remainder: Range<usize> =
-                                Range { start: incumbent.start, end: range.start - 1 };
-                            let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
-                            self.0.remove(incumbent);
-                            self.0.insert(remainder, old_opcode);
-                        } else {
-                            let remainder: Range<usize> =
-                                Range { start: range.end + 1, end: incumbent.end };
-                            let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
-                            self.0.remove(incumbent);
-                            self.0.insert(remainder, old_opcode);
-                        }
+                    } 
+                    else {
+                        // raise an error: this should be impossible
+                        assert!(false, "range_map::write: impossible case");
                     }
                 }
-
                 self.0.insert(range.clone(), opcode.clone());
             });
         }
     }
 
-    fn classify_collision(incoming: &Range<usize>, incumbent: &Range<usize>) -> CollisionKind {
-        let range_needs_deletion = |incoming: &Range<usize>, incumbent: &Range<usize>| {
-            incoming.start <= incumbent.start && incoming.end >= incumbent.end
-        };
-        let range_needs_splitting = |incoming: &Range<usize>, incumbent: &Range<usize>| {
-            incoming.start > incumbent.start && incoming.end < incumbent.end
-        };
-
-        if range_needs_deletion(incoming, incumbent) {
-            CollisionKind::Deletion
-        } else if range_needs_splitting(incoming, incumbent) {
-            CollisionKind::Splitting
-        } else {
-            CollisionKind::Shortening
-        }
-    }
 
     fn find_range(&self, offset: usize) -> Option<&Range<usize>> {
         self.0.keys().find(|range| range.contains(&offset))

--- a/common/src/utils/range_map.rs
+++ b/common/src/utils/range_map.rs
@@ -32,9 +32,9 @@ impl RangeMap {
             self.0.insert(range, opcode);
         } else {
             incumbents.iter().for_each(|incumbent| {
-                if incumbent.end < range.start {}
-                else if incumbent.start > range.end {}
-                else {
+                if incumbent.end < range.start {
+                } else if incumbent.start > range.end {
+                } else {
                     // Case 1: overlapping
                     if range.start <= incumbent.start && range.end >= incumbent.end {
                         // newInterval completely covers incumbent
@@ -43,28 +43,29 @@ impl RangeMap {
                     }
                     // Case 2: shortening
                     else if range.start <= incumbent.start && range.end < incumbent.end {
-                        let remainder: Range<usize> = Range { start: range.end + 1, end: incumbent.end };
+                        let remainder: Range<usize> =
+                            Range { start: range.end + 1, end: incumbent.end };
                         let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
                         self.0.remove(incumbent);
                         self.0.insert(remainder, old_opcode);
-                        
                     } else if range.start > incumbent.start && range.end >= incumbent.end {
-                        let remainder: Range<usize> = Range { start: incumbent.start, end: range.start - 1 };
+                        let remainder: Range<usize> =
+                            Range { start: incumbent.start, end: range.start - 1 };
                         let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
                         self.0.remove(incumbent);
                         self.0.insert(remainder, old_opcode);
-                        
-                    } 
+                    }
                     // Case 3: splitting
-                    else if range.start > incumbent.start && range.end < incumbent.end {    
-                        let left: Range<usize> = Range { start: incumbent.start, end: range.start - 1 };
-                        let right: Range<usize> = Range { start: range.end + 1, end: incumbent.end };
+                    else if range.start > incumbent.start && range.end < incumbent.end {
+                        let left: Range<usize> =
+                            Range { start: incumbent.start, end: range.start - 1 };
+                        let right: Range<usize> =
+                            Range { start: range.end + 1, end: incumbent.end };
                         let old_opcode: WrappedOpcode = self.0.get(incumbent).cloned().unwrap();
                         self.0.remove(incumbent);
                         self.0.insert(left, old_opcode.clone());
                         self.0.insert(right, old_opcode.clone());
-                    } 
-                    else {
+                    } else {
                         // raise an error: this should be impossible
                         assert!(false, "range_map::write: impossible case");
                     }
@@ -73,7 +74,6 @@ impl RangeMap {
             });
         }
     }
-
 
     fn find_range(&self, offset: usize) -> Option<&Range<usize>> {
         self.0.keys().find(|range| range.contains(&offset))
@@ -84,12 +84,12 @@ impl RangeMap {
     }
 
     fn range_collides(incoming: &Range<usize>, incumbent: &Range<usize>) -> bool {
-        !(incoming.start <= incumbent.start &&
-            incoming.end < incumbent.end &&
-            incoming.end < incumbent.start ||
-            incoming.start > incumbent.start &&
-                incoming.end >= incumbent.end &&
-                incoming.start > incumbent.end)
+        !(incoming.start <= incumbent.start
+            && incoming.end < incumbent.end
+            && incoming.end < incumbent.start
+            || incoming.start > incumbent.start
+                && incoming.end >= incumbent.end
+                && incoming.start > incumbent.end)
     }
 }
 

--- a/common/src/utils/range_map.rs
+++ b/common/src/utils/range_map.rs
@@ -84,12 +84,12 @@ impl RangeMap {
     }
 
     fn range_collides(incoming: &Range<usize>, incumbent: &Range<usize>) -> bool {
-        !(incoming.start <= incumbent.start
-            && incoming.end < incumbent.end
-            && incoming.end < incumbent.start
-            || incoming.start > incumbent.start
-                && incoming.end >= incumbent.end
-                && incoming.start > incumbent.end)
+        !(incoming.start <= incumbent.start &&
+            incoming.end < incumbent.end &&
+            incoming.end < incumbent.start ||
+            incoming.start > incumbent.start &&
+                incoming.end >= incumbent.end &&
+                incoming.start > incumbent.end)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
``
Bug fixes and new features should include tests.
-->

## Motivation
I failed to run `heavy_test_snapshot_thorough` test in the file `core/tests/test_snapshot.rs` 

I always encoutered a substract underflow error. 

After investigation, I believe there is something wrong within the original `write` function in the file `common/src/utils/range_map.rs`. There is something wrong when merging new `range` and `incumbents`


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I rewrote part of the code. 

It's the same logic but in a straightforward implementation. It has shorter lines of code and easier to maintain. 

After my fix, now `heavy_test_snapshot_thorough` can pass without any error. 



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
