### PR TITLE
fix(vm): clamp `U256` conversions to `<type>::MAX`

### DIFF
--- a/common/src/ether/evm/core/vm.rs
+++ b/common/src/ether/evm/core/vm.rs
@@ -689,9 +689,7 @@ impl VM {
                 let b = self.stack.pop();
 
                 // convert a to usize
-                let usize_a: usize = a.value.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert SAR shift to usize".to_string())
-                })?;
+                let usize_a: usize = a.value.try_into().unwrap_or(usize::MAX);
 
                 let mut result = I256::zero();
                 if !b.value.is_zero() {
@@ -716,12 +714,8 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert SHA3 offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert SHA3 size to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let data = self.memory.read(offset, size);
                 let result = keccak256(data);
@@ -785,9 +779,7 @@ impl VM {
                 let i = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let i: usize = i.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert CALLDATALOAD offset to usize".to_string())
-                })?;
+                let i: usize = i.try_into().unwrap_or(usize::MAX);
 
                 let result = if i + 32 > self.calldata.len() {
                     let mut value = [0u8; 32];
@@ -818,17 +810,9 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().map_err(|_| {
-                    Error::ParseError(
-                        "failed to convert CALLDATACOPY destination offset to usize".to_string(),
-                    )
-                })?;
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert CALLDATACOPY offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert CALLDATACOPY size to usize".to_string())
-                })?;
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let value_offset_safe = (offset + size).min(self.calldata.len());
                 let mut value =
@@ -861,17 +845,9 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().map_err(|_| {
-                    Error::ParseError(
-                        "failed to convert CODECOPY destination offset to usize".to_string(),
-                    )
-                })?;
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert CODECOPY offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert CODECOPY size to usize".to_string())
-                })?;
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let value_offset_safe = (offset + size).min(self.bytecode.len());
                 let mut value =
@@ -918,14 +894,8 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().map_err(|_| {
-                    Error::ParseError(
-                        "failed to convert EXTCODECOPY destination offset to usize".to_string(),
-                    )
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert EXTCODECOPY size to usize".to_string())
-                })?;
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let mut value = Vec::with_capacity(size);
                 value.resize(size, 0xff);
@@ -957,14 +927,8 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().map_err(|_| {
-                    Error::ParseError(
-                        "failed to convert RETURNDATACOPY destination offset to usize".to_string(),
-                    )
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert RETURNDATACOPY size to usize".to_string())
-                })?;
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let mut value = Vec::with_capacity(size);
                 value.resize(size, 0xff);
@@ -1021,9 +985,7 @@ impl VM {
                 let i = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let i: usize = i.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert MLOAD offset to usize".to_string())
-                })?;
+                let i: usize = i.try_into().unwrap_or(usize::MAX);
 
                 let result = U256::from(self.memory.read(i, 32).as_slice());
 
@@ -1040,9 +1002,7 @@ impl VM {
                 let value = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert MSTORE offset to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
 
                 // consume dynamic gas
                 let gas_cost = self.memory.expansion_cost(offset, 32);
@@ -1057,9 +1017,7 @@ impl VM {
                 let value = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert MSTORE8 offset to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
 
                 // consume dynamic gas
                 let gas_cost = self.memory.expansion_cost(offset, 1);
@@ -1096,9 +1054,7 @@ impl VM {
                 let pc = self.stack.pop().value;
 
                 // Safely convert U256 to u128
-                let pc: u128 = pc.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert JUMP destination to u128".to_string())
-                })?;
+                let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
                 // Check if JUMPDEST is valid and throw with 790 if not (invalid jump destination)
                 if (pc <=
@@ -1129,9 +1085,7 @@ impl VM {
                 let condition = self.stack.pop().value;
 
                 // Safely convert U256 to u128
-                let pc: u128 = pc.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert JUMPI destination to u128".to_string())
-                })?;
+                let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
                 if !condition.eq(&U256::from(0u8)) {
                     // Check if JUMPDEST is valid and throw with 790 if not (invalid jump
@@ -1241,12 +1195,8 @@ impl VM {
                     self.stack.pop_n(topic_count as usize).iter().map(|x| x.value).collect();
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert LOG offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert LOG size to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 let data = self.memory.read(offset, size);
 
@@ -1297,12 +1247,8 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert RETURN offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert RETURN size to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 // consume dynamic gas
                 let gas_cost = self.memory.expansion_cost(offset, size);
@@ -1340,12 +1286,8 @@ impl VM {
                 let size = self.stack.pop().value;
 
                 // Safely convert U256 to usize
-                let offset: usize = offset.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert REVERT offset to usize".to_string())
-                })?;
-                let size: usize = size.try_into().map_err(|_| {
-                    Error::ParseError("failed to convert REVERT size to usize".to_string())
-                })?;
+                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
+                let size: usize = size.try_into().unwrap_or(usize::MAX);
 
                 self.exit(1, self.memory.read(offset, size));
             }

--- a/common/src/ether/evm/ext/exec/mod.rs
+++ b/common/src/ether/evm/ext/exec/mod.rs
@@ -90,6 +90,7 @@ impl VM {
 
         // step through the bytecode until we find a JUMPI instruction
         while vm.bytecode.len() >= vm.instruction as usize {
+            // execute the next instruction. if the instruction panics, invalidate this path
             let state = vm.step()?;
 
             // update vm_trace


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Resolves #332 

## Solution

When converting EVM values from `U256` to rust types `usize` and `u128`, we clamp the values to `<type>::MAX` rather than excepting. When symbolically executing a contract, we are bound to get huge and weird values, and we should support these cases without excepting.

Culprit: `0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC`