### PR TITLE
fix: change "bytes memory" to "bytes" in json abi output

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.50"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 eyre = "0.6.12"
-alloy-json-abi = "0.7.0"
+alloy-json-abi = "0.7.4"
 
 [[bin]]
 name = "heimdall"

--- a/crates/common/src/ether/signatures.rs
+++ b/crates/common/src/ether/signatures.rs
@@ -226,7 +226,7 @@ impl ResolveSelector for ResolvedFunction {
             None => selector,
         };
 
-        trace!("resolving event selector {}", &selector);
+        trace!("resolving function selector {}", &selector);
 
         // get cached results
         if let Some(cached_results) =

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ derive_builder = "0.12.0"
 async-convert = "1.0.0"
 futures = "0.3.28"
 tracing = "0.1.40"
+alloy-json-abi = { version = "0.7.4", features = ["serde_json"]}
 
 # modules
 heimdall-cfg = { workspace = true }

--- a/crates/core/tests/test_decompile.rs
+++ b/crates/core/tests/test_decompile.rs
@@ -126,6 +126,7 @@ mod benchmark {
 
 #[cfg(test)]
 mod integration_tests {
+    use alloy_json_abi::JsonAbi;
     use heimdall_common::utils::io::file::delete_path;
     use heimdall_decompiler::{decompile, DecompilerArgs};
 
@@ -391,6 +392,10 @@ mod integration_tests {
             if output.contains("error CustomError_") {
                 is_error_covered = true;
             }
+
+            let abi_serialized = serde_json::to_string(&result.abi).unwrap();
+            let abi_deserialized = JsonAbi::from_json_str(&abi_serialized);
+            assert!(abi_deserialized.is_ok());
         }
 
         // assert that all flags are true

--- a/crates/decompile/Cargo.toml
+++ b/crates/decompile/Cargo.toml
@@ -17,7 +17,7 @@ heimdall-cache = { workspace = true }
 thiserror = "1.0.50"
 clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
-alloy-json-abi = "0.7.0"
+alloy-json-abi = "0.7.4"
 tracing = "0.1.40"
 eyre = "0.6.12"
 ethers = "2.0.4"

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -68,7 +68,7 @@ pub fn build_abi(
                     vec![Param {
                         name: "".to_string(),
                         internal_type: None,
-                        ty: r.clone(),
+                        ty: if r == "bytes memory" { "bytes".to_string() } else { r.clone() },
                         components: vec![],
                     }]
                 })

--- a/crates/decompile/src/utils/heuristics/arguments.rs
+++ b/crates/decompile/src/utils/heuristics/arguments.rs
@@ -138,10 +138,10 @@ pub fn argument_heuristic(
             {
                 function.returns = Some(String::from("address"));
             }
-            // if the size of returndata is > 32, it must be a bytes memory return.
+            // if the size of returndata is > 32, it must be a bytes return.
             // it could be a struct, but we cant really determine that from the bytecode
             else if size > 32 {
-                function.returns = Some(String::from("bytes memory"));
+                function.returns = Some(String::from("bytes"));
             } else {
                 // attempt to find a return type within the return memory operations
                 let byte_size = match AND_BITMASK_REGEX

--- a/crates/decompile/src/utils/heuristics/arguments.rs
+++ b/crates/decompile/src/utils/heuristics/arguments.rs
@@ -138,10 +138,10 @@ pub fn argument_heuristic(
             {
                 function.returns = Some(String::from("address"));
             }
-            // if the size of returndata is > 32, it must be a bytes return.
+            // if the size of returndata is > 32, it must be a bytes memory return.
             // it could be a struct, but we cant really determine that from the bytecode
             else if size > 32 {
-                function.returns = Some(String::from("bytes"));
+                function.returns = Some(String::from("bytes memory"));
             } else {
                 // attempt to find a return type within the return memory operations
                 let byte_size = match AND_BITMASK_REGEX


### PR DESCRIPTION
## Motivation
Heimdall-rs uses now alloy-json-abi to handle the ABI in decompile step, but the library doesn't accept the "bytes memory" as a token for an output type.

## Solution
- Change "bytes memory" to "bytes" in the ABI output string. 
- The steps to serialize and deserialize are added to the `heavy_test_decompile_thorough` UT. 
- Upgraded alloy-json-abi to 0.7.4.