### PR TITLE
fix(decompile): handle tuple arguments correctly in ABI/source generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3abf6446a292e19853aaca43590eeb48bf435dfd2c74200259e8f4872f6ce3"
+checksum = "aaeaccd50238126e3a0ff9387c7c568837726ad4f4e399b528ca88104d6c25ef"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277af0cbcc483ee6ad2c1e818090b5928d27f04fd6580680f31c1cf8068bcc2"
+checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fd4783b0a5840479013e9ce960d2eb7b3be381f722e0fe3d1f7c3bb6bd4ebd"
+checksum = "baa2fbd22d353d8685bd9fee11ba2d8b5c3b1d11e56adb3265fcf1f32bfdf404"
 dependencies = [
  "winnow 0.6.13",
 ]
@@ -1978,6 +1978,7 @@ dependencies = [
 name = "heimdall-common"
 version = "0.8.2"
 dependencies = [
+ "alloy-json-abi",
  "async-openai",
  "async-recursion",
  "async-trait",

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -19,7 +19,7 @@ clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
 tracing = "0.1.40"
 eyre = "0.6.12"
-ethers = "2.0.4"
+ethers = "2.0.14"
 futures = "0.3.30"
 lazy_static = "1.4.0"
 petgraph = "0.6.2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.50"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 eyre = "0.6.12"
-alloy-json-abi = "0.7.4"
+alloy-json-abi = "0.7.6"
 
 [[bin]]
 name = "heimdall"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -15,7 +15,7 @@ async-openai = "0.10.0"
 clap = { workspace = true, features = ["derive"] }
 colored = "2"
 crossbeam-channel = "0.5.7"
-ethers = { version = "2.0.4", features = ["ipc", "ws"] }
+ethers = { version = "2.0.14", features = ["ipc", "ws"] }
 fancy-regex = "0.11.0"
 heimdall-cache = { workspace = true }
 indicatif = "0.17.0"
@@ -33,3 +33,4 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 thiserror = "1.0.50"
 tracing = "0.1.40"
 eyre = "0.6.12"
+alloy-json-abi = "0.7.6"

--- a/crates/common/src/ether/mod.rs
+++ b/crates/common/src/ether/mod.rs
@@ -5,3 +5,4 @@ pub mod http_or_ws_or_ipc;
 pub mod rpc;
 pub mod signatures;
 pub mod tokenize;
+pub mod types;

--- a/crates/common/src/ether/signatures.rs
+++ b/crates/common/src/ether/signatures.rs
@@ -1,11 +1,13 @@
 use async_trait::async_trait;
-use ethers::abi::Token;
+use ethers::abi::{ParamType, Token};
 
+use eyre::Result;
 use heimdall_cache::{read_cache, store_cache};
 use tracing::trace;
 
 use crate::{
     error::Error,
+    ether::types::parse_function_parameters,
     utils::{
         http::get_json_from_url,
         io::{logging::TraceFactory, types::display},
@@ -22,6 +24,12 @@ pub struct ResolvedFunction {
     pub decoded_inputs: Option<Vec<Token>>,
 }
 
+impl ResolvedFunction {
+    pub fn inputs(&self) -> Vec<ParamType> {
+        parse_function_parameters(&self.signature).expect("invalid signature")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ResolvedError {
     pub name: String,
@@ -29,11 +37,23 @@ pub struct ResolvedError {
     pub inputs: Vec<String>,
 }
 
+impl ResolvedError {
+    pub fn inputs(&self) -> Vec<ParamType> {
+        parse_function_parameters(&self.signature).expect("invalid signature")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ResolvedLog {
     pub name: String,
     pub signature: String,
     pub inputs: Vec<String>,
+}
+
+impl ResolvedLog {
+    pub fn inputs(&self) -> Vec<ParamType> {
+        parse_function_parameters(&self.signature).expect("invalid signature")
+    }
 }
 
 #[async_trait]

--- a/crates/common/src/ether/types.rs
+++ b/crates/common/src/ether/types.rs
@@ -15,7 +15,7 @@ pub enum Padding {
 /// Parse function parameters [`ParamType`]s from a function signature.
 ///
 /// ```
-/// use heimdall_vm::core::types::parse_function_parameters;
+/// use heimdall_common::ether::types::parse_function_parameters;
 /// use ethers::abi::ParamType;
 ///
 /// let function_signature = "foo(uint256,uint256)";

--- a/crates/common/src/ether/types.rs
+++ b/crates/common/src/ether/types.rs
@@ -1,16 +1,160 @@
-use std::{collections::VecDeque, ops::Range};
+use alloy_json_abi::Param;
+use std::collections::VecDeque;
 
-use ethers::abi::{AbiEncode, ParamType};
-use eyre::{eyre, Result};
-use heimdall_common::{constants::TYPE_CAST_REGEX, utils::strings::find_balanced_encapsulator};
-
-use super::{opcodes::WrappedInput, vm::Instruction};
+use crate::utils::strings::find_balanced_encapsulator;
+use ethers::abi::ParamType;
+use eyre::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Padding {
     Left,
     Right,
     None,
+}
+
+/// Parse function parameters [`ParamType`]s from a function signature.
+///
+/// ```
+/// use heimdall_vm::core::types::parse_function_parameters;
+/// use ethers::abi::ParamType;
+///
+/// let function_signature = "foo(uint256,uint256)";
+/// let function_parameters = parse_function_parameters(function_signature)
+///     .expect("failed to parse function parameters");
+///
+/// assert_eq!(function_parameters, vec![ParamType::Uint(256), ParamType::Uint(256)]);
+/// ```
+pub fn parse_function_parameters(function_signature: &str) -> Result<Vec<ParamType>> {
+    // remove the function name from the signature, only keep the parameters
+    let param_range = find_balanced_encapsulator(function_signature, ('(', ')'))?;
+
+    let function_inputs = function_signature[param_range].to_string();
+
+    // get inputs from the string
+    extract_types_from_string(&function_inputs)
+}
+
+/// Helper function for extracting types from a string. Used by [`parse_function_parameters`],
+/// typically after entering a nested tuple or similar.
+fn extract_types_from_string(string: &str) -> Result<Vec<ParamType>> {
+    let mut types = Vec::new();
+    if string.is_empty() {
+        return Ok(types);
+    }
+
+    // if the string contains a tuple we cant simply split on commas
+    if ['(', ')'].iter().any(|c| string.contains(*c)) {
+        // check if first type is a tuple
+        if is_first_type_tuple(string) {
+            // get balanced encapsulator
+            let tuple_range = find_balanced_encapsulator(string, ('(', ')'))?;
+
+            // extract the tuple
+            let tuple_types = string[tuple_range.clone()].to_string();
+
+            // remove the tuple from the string
+            let mut string = string[tuple_range.end + 1..].to_string();
+
+            // if string is not empty, split on commas and check if tuple is an array
+            let mut is_array = false;
+            let mut array_size: Option<usize> = None;
+            if !string.is_empty() {
+                let split = string.splitn(2, ',').collect::<Vec<&str>>()[0];
+
+                is_array = split.ends_with(']');
+
+                // get array size, or none if []
+                if is_array {
+                    let array_range = find_balanced_encapsulator(split, ('[', ']'))?;
+
+                    let size = split[array_range].to_string();
+                    array_size = match size.parse::<usize>() {
+                        Ok(size) => Some(size),
+                        Err(_) => None,
+                    };
+                }
+            }
+
+            if is_array {
+                // if the string doesnt contain a comma, this is the last type
+                if string.contains(',') {
+                    // remove the array from the string by splitting on the first comma and taking
+                    // the second half
+                    string = string.splitn(2, ',').collect::<Vec<&str>>()[1].to_string();
+                } else {
+                    // set string to empty string
+                    string = "".to_string();
+                }
+
+                if let Some(array_size) = array_size {
+                    // recursively call this function to extract the tuple types
+                    let inner_types = extract_types_from_string(&tuple_types)?;
+
+                    types.push(ParamType::FixedArray(
+                        Box::new(ParamType::Tuple(inner_types)),
+                        array_size,
+                    ))
+                } else {
+                    // recursively call this function to extract the tuple types
+                    let inner_types = extract_types_from_string(&tuple_types)?;
+
+                    types.push(ParamType::Array(Box::new(ParamType::Tuple(inner_types))))
+                }
+            } else {
+                // recursively call this function to extract the tuple types
+                let inner_types = extract_types_from_string(&tuple_types)?;
+
+                types.push(ParamType::Tuple(inner_types));
+            }
+
+            // recursively call this function to extract the remaining types
+            types.append(&mut extract_types_from_string(&string)?);
+        } else {
+            // first type is not a tuple, so we can extract it
+            let string_parts = string.splitn(2, ',').collect::<Vec<&str>>();
+
+            // convert the string type to a ParamType
+            if string_parts[0].is_empty() {
+                // the first type is empty, so we can just recursively call this function to extract
+                // the remaining types
+                types.append(&mut extract_types_from_string(string_parts[1])?);
+            } else {
+                let param_type = to_type(string_parts[0]);
+                types.push(param_type);
+
+                // remove the first type from the string
+                let string = string[string_parts[0].len() + 1..].to_string();
+
+                // recursively call this function to extract the remaining types
+                types.append(&mut extract_types_from_string(&string)?);
+            }
+        }
+    } else {
+        // split on commas
+        let split = string.split(',').collect::<Vec<&str>>();
+
+        // iterate over the split string and convert each type to a ParamType
+        for string_type in split {
+            if string_type.is_empty() {
+                continue;
+            }
+
+            let param_type = to_type(string_type);
+            types.push(param_type);
+        }
+    }
+
+    Ok(types)
+}
+
+/// A helper function used by [`extract_types_from_string`] to check if the first type in a string
+/// is a tuple.
+fn is_first_type_tuple(string: &str) -> bool {
+    // split by first comma
+    let split = string.splitn(2, ',').collect::<Vec<&str>>();
+
+    // if the first element starts with a (, it is a tuple
+    split[0].starts_with('(')
 }
 
 /// A helper function used by [`extract_types_from_string`] that converts a string type to a
@@ -80,181 +224,38 @@ pub fn to_type(string: &str) -> ParamType {
     arg_type
 }
 
-/// Convert a bitwise masking operation to a tuple containing: \
-/// 1. The size of the type being masked \
-/// 2. Potential types that the type being masked could be.
-pub fn convert_bitmask(instruction: &Instruction) -> (usize, Vec<String>) {
-    let mask = &instruction.output_operations[0];
-
-    // use 32 as the default size, as it is the default word size in the EVM
-    let mut type_byte_size = 32;
-
-    // determine which input contains the bitmask
-    for (i, input) in mask.inputs.iter().enumerate() {
-        match input {
-            WrappedInput::Raw(_) => continue,
-            WrappedInput::Opcode(opcode) => {
-                if !(opcode.opcode.name == "CALLDATALOAD" || opcode.opcode.name == "CALLDATACOPY") {
-                    if mask.opcode.name == "AND" {
-                        type_byte_size = instruction.inputs[i].encode_hex().matches("ff").count();
-                    } else if mask.opcode.name == "OR" {
-                        type_byte_size = instruction.inputs[i].encode_hex().matches("00").count();
-                    }
-                }
-            }
-        };
-    }
-
-    // determine the solidity type based on the resulting size of the masked data
-    byte_size_to_type(type_byte_size)
-}
-
-/// Given a byte size, return a tuple containing: \
-/// 1. The byte size \
-/// 2. Potential types that the byte size could be.
-///
-/// ```
-/// use heimdall_vm::core::types::byte_size_to_type;
-///
-/// let (byte_size, potential_types) = byte_size_to_type(1);
-/// assert_eq!(byte_size, 1);
-/// assert_eq!(potential_types, vec!["bool".to_string(), "uint8".to_string(), "bytes1".to_string(), "int8".to_string()]);
-/// ```
-pub fn byte_size_to_type(byte_size: usize) -> (usize, Vec<String>) {
-    let mut potential_types = Vec::new();
-
-    match byte_size {
-        1 => potential_types.push("bool".to_string()),
-        15..=20 => potential_types.push("address".to_string()),
-        _ => {}
-    }
-
-    // push arbitrary types to the array
-    potential_types.push(format!("uint{}", byte_size * 8));
-    potential_types.push(format!("bytes{byte_size}"));
-    potential_types.push(format!("int{}", byte_size * 8));
-
-    // return list of potential type castings, sorted by likelihood descending
-    (byte_size, potential_types)
-}
-
-/// Given a string (typically a line of decompiled source code), extract a type cast if one exists.
-///
-/// ```
-/// use heimdall_vm::core::types::find_cast;
-/// use ethers::abi::ParamType;
-///
-/// let line = "uint256(0x000011)";
-/// let (range, cast_type) = find_cast(line).expect("failed to find type cast");
-/// assert_eq!(range, 8..16);
-/// assert_eq!(&line[range], "0x000011");
-/// assert_eq!(cast_type, ParamType::Uint(256));
-/// ```
-pub fn find_cast(line: &str) -> Result<(Range<usize>, ParamType)> {
-    // find the start of the cast
-    match TYPE_CAST_REGEX.find(line).expect("Failed to find type cast.") {
-        Some(m) => {
-            let start = m.start();
-            let end = m.end() - 1;
-            let cast_type = line[start..].split('(').collect::<Vec<&str>>()[0].to_string();
-
-            // find where the cast ends
-            let range = find_balanced_encapsulator(&line[end..], ('(', ')'))?;
-            Ok((end + range.start..end + range.end, to_type(&cast_type)))
-        }
-        None => Err(eyre!("failed to find type cast")),
+/// Convert a given ParamType to its abi-safe "type" string representation
+pub fn to_abi_string(param_type: &ParamType) -> String {
+    match param_type {
+        ParamType::Array(inner) => format!("{}[]", to_abi_string(inner)),
+        ParamType::FixedArray(inner, size) => format!("{}[{}]", to_abi_string(inner), size),
+        ParamType::Tuple(_) => "tuple".to_string(),
+        _ => param_type.to_string(),
     }
 }
 
-/// Given a string of bytes, determine if it is left or right padded.
-pub fn get_padding(bytes: &[u8]) -> Padding {
-    let size = bytes.len();
-
-    // get indices of null bytes in the decoded bytes
-    let null_byte_indices = bytes
-        .iter()
-        .enumerate()
-        .filter(|(_, byte)| **byte == 0)
-        .map(|(index, _)| index)
-        .collect::<Vec<usize>>();
-
-    // we can avoid doing a full check if any of the following are true:
-    // there are no null bytes OR
-    // neither first nor last byte is a null byte, it is not padded
-    if null_byte_indices.is_empty() ||
-        null_byte_indices[0] != 0 && null_byte_indices[null_byte_indices.len() - 1] != size - 1
-    {
-        return Padding::None;
+/// Convert a given ParamType to its abi-safe "components"
+pub fn to_components(param_type: &ParamType) -> Vec<Param> {
+    match param_type {
+        ParamType::Array(inner) | ParamType::FixedArray(inner, _) => to_components(inner),
+        ParamType::Tuple(params) => params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| Param {
+                ty: to_abi_string(p),
+                name: format!("component{}", i),
+                components: to_components(p),
+                internal_type: None,
+            })
+            .collect::<Vec<_>>(),
+        _ => vec![],
     }
-
-    // the first byte is a null byte AND the last byte is not a null byte, it is left padded
-    if null_byte_indices[0] == 0 && null_byte_indices[null_byte_indices.len() - 1] != size - 1 {
-        return Padding::Left;
-    }
-
-    // the first byte is not a null byte AND the last byte is a null byte, it is right padded
-    if null_byte_indices[0] != 0 && null_byte_indices[null_byte_indices.len() - 1] == size - 1 {
-        return Padding::Right;
-    }
-
-    // get non-null byte indices
-    let non_null_byte_indices = bytes
-        .iter()
-        .enumerate()
-        .filter(|(_, byte)| **byte != 0)
-        .map(|(index, _)| index)
-        .collect::<Vec<usize>>();
-
-    if non_null_byte_indices.is_empty() {
-        return Padding::None;
-    }
-
-    // check if the there are more null-bytes before the first non-null byte than after the last
-    // non-null byte
-    let left_hand_padding =
-        null_byte_indices.iter().filter(|index| **index < non_null_byte_indices[0]).count();
-    let right_hand_padding = null_byte_indices
-        .iter()
-        .filter(|index| **index > non_null_byte_indices[non_null_byte_indices.len() - 1])
-        .count();
-
-    match left_hand_padding.cmp(&right_hand_padding) {
-        std::cmp::Ordering::Greater => Padding::Left,
-        std::cmp::Ordering::Less => Padding::Right,
-        std::cmp::Ordering::Equal => Padding::None,
-    }
-}
-
-/// Given a string of bytes, get the max padding size for the data
-pub fn get_padding_size(bytes: &[u8]) -> usize {
-    match get_padding(bytes) {
-        Padding::Left => {
-            // count number of null-bytes at the start of the data
-            bytes.iter().take_while(|byte| **byte == 0).count()
-        }
-        Padding::Right => {
-            // count number of null-bytes at the end of the data
-            bytes.iter().rev().take_while(|byte| **byte == 0).count()
-        }
-        _ => 0,
-    }
-}
-
-// Get minimum size needed to store the given word
-pub fn get_potential_types_for_word(word: &[u8]) -> (usize, Vec<String>) {
-    // get padding of the word, note this is a maximum
-    let padding_size = get_padding_size(word);
-
-    // get number of bytes padded
-    let data_size = word.len() - padding_size;
-    byte_size_to_type(data_size)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use ethers::abi::ParamType;
-    use heimdall_common::{ether::types::parse_function_parameters, utils::strings::decode_hex};
 
     #[test]
     fn test_simple_signature() {
@@ -469,97 +470,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_padding_no_padding() {
-        // No padding, input contains no null bytes
-        let input = "11".repeat(32);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::None);
-    }
-
-    #[test]
-    fn test_get_padding_left_padding() {
-        // Left padded, first byte is null
-        let input = "00".repeat(31) + "11";
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Left);
-    }
-
-    #[test]
-    fn test_get_padding_right_padding() {
-        // Right padding, last byte is null
-        let input = "11".to_owned() + &"00".repeat(31);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Right);
-    }
-
-    #[test]
-    fn test_get_padding_skewed_left_padding() {
-        // Both left and right null-bytes, but still left padded
-        let input = "00".repeat(30) + "1100";
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Left);
-    }
-
-    #[test]
-    fn test_get_padding_skewed_right_padding() {
-        // Both left and right null-bytes, but still right padded
-        let input = "0011".to_owned() + &"00".repeat(30);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Right);
-    }
-
-    #[test]
-    fn test_get_padding_empty_input() {
-        // Empty input should result in no padding
-        let input = "";
-        assert_eq!(get_padding(&decode_hex(input).expect("failed to decode hex")), Padding::None);
-    }
-
-    #[test]
-    fn test_get_padding_single_byte() {
-        // Single-byte input with null byte
-        let input = "00";
-        assert_eq!(get_padding(&decode_hex(input).expect("failed to decode hex")), Padding::None);
-    }
-
-    #[test]
-    fn test_get_padding_single_byte_left_padding() {
-        // Single-byte input with left padding
-        let input = "0011";
-        assert_eq!(get_padding(&decode_hex(input).expect("failed to decode hex")), Padding::Left);
-    }
-
-    #[test]
-    fn test_get_padding_single_byte_right_padding() {
-        // Single-byte input with right padding
-        let input = "1100";
-        assert_eq!(get_padding(&decode_hex(input).expect("failed to decode hex")), Padding::Right);
-    }
-
-    #[test]
-    fn test_get_padding_single_byte_both_padding() {
-        // Single-byte input with both left and right padding
-        let input = "001100";
-        assert_eq!(get_padding(&decode_hex(input).expect("failed to decode hex")), Padding::None);
-    }
-
-    #[test]
-    fn test_get_padding_mixed_padding() {
-        // Mixed padding, some null bytes in the middle
-        let input = "00".repeat(10) + "1122330000332211" + &"00".repeat(10);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::None);
-    }
-
-    #[test]
-    fn test_get_padding_mixed_padding_skewed_left() {
-        // Mixed padding, some null bytes in the middle
-        let input = "00".repeat(10) + "001122330000332211" + &"00".repeat(10);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Left);
-    }
-
-    #[test]
-    fn test_get_padding_mixed_padding_skewed_right() {
-        // Mixed padding, some null bytes in the middle
-        let input = "00".repeat(10) + "112233000033221100" + &"00".repeat(10);
-        assert_eq!(get_padding(&decode_hex(&input).expect("failed to decode hex")), Padding::Right);
-    }
-
-    #[test]
     fn test_to_type_address() {
         let input = "address";
         assert_eq!(super::to_type(input), ParamType::Address);
@@ -653,5 +563,47 @@ mod tests {
                 2
             )
         );
+    }
+
+    #[test]
+    fn test_to_abi_string_simple() {
+        let input = ParamType::String;
+        assert_eq!(super::to_abi_string(&input), "string");
+    }
+
+    #[test]
+    fn test_to_abi_string_array() {
+        let input = ParamType::Array(Box::new(ParamType::Uint(8)));
+        assert_eq!(super::to_abi_string(&input), "uint8[]");
+    }
+
+    #[test]
+    fn test_to_abi_string_fixed_array() {
+        let input = ParamType::FixedArray(Box::new(ParamType::Uint(8)), 2);
+        assert_eq!(super::to_abi_string(&input), "uint8[2]");
+    }
+
+    #[test]
+    fn test_to_abi_string_tuple() {
+        let input = ParamType::Tuple(vec![ParamType::Uint(8), ParamType::Uint(256)]);
+        assert_eq!(super::to_abi_string(&input), "tuple");
+    }
+
+    #[test]
+    fn test_to_components_simple() {
+        let input = ParamType::String;
+        assert_eq!(super::to_components(&input), vec![]);
+    }
+
+    #[test]
+    fn test_to_components_array() {
+        let input = ParamType::Array(Box::new(ParamType::Uint(8)));
+        assert_eq!(super::to_components(&input), vec![]);
+    }
+
+    #[test]
+    fn test_to_components_tuple() {
+        let input = ParamType::Tuple(vec![ParamType::Uint(8), ParamType::Uint(256)]);
+        assert_eq!(super::to_components(&input).len(), 2);
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ async-recursion = "1.0.5"
 thiserror = "1.0.50"
 clap = { workspace = true, features = ["derive"] }
 colored = "2"
-ethers = "2.0.4"
+ethers = "2.0.14"
 fancy-regex = "0.11.0"
 heimdall-cache = { workspace = true }
 heimdall-common = { workspace = true }
@@ -31,7 +31,7 @@ derive_builder = "0.12.0"
 async-convert = "1.0.0"
 futures = "0.3.28"
 tracing = "0.1.40"
-alloy-json-abi = { version = "0.7.4", features = ["serde_json"]}
+alloy-json-abi = { version = "0.7.6", features = ["serde_json"]}
 
 # modules
 heimdall-cfg = { workspace = true }

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -19,5 +19,5 @@ clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
 tracing = "0.1.40"
 eyre = "0.6.12"
-ethers = "2.0.4"
+ethers = "2.0.14"
 heimdall-vm.workspace = true

--- a/crates/decode/src/core/mod.rs
+++ b/crates/decode/src/core/mod.rs
@@ -6,12 +6,11 @@ use heimdall_common::{
     ether::{
         calldata::get_calldata_from_target,
         signatures::{score_signature, ResolveSelector, ResolvedFunction},
+        types::parse_function_parameters,
     },
     utils::{io::logging::TraceFactory, strings::encode_hex},
 };
-use heimdall_vm::core::types::{
-    get_padding, get_potential_types_for_word, parse_function_parameters, to_type, Padding,
-};
+use heimdall_vm::core::types::{get_padding, get_potential_types_for_word, to_type, Padding};
 use tracing::{debug, info, trace, warn};
 
 use crate::{

--- a/crates/decompile/Cargo.toml
+++ b/crates/decompile/Cargo.toml
@@ -17,10 +17,10 @@ heimdall-cache = { workspace = true }
 thiserror = "1.0.50"
 clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
-alloy-json-abi = "0.7.4"
+alloy-json-abi = "0.7.6"
 tracing = "0.1.40"
 eyre = "0.6.12"
-ethers = "2.0.4"
+ethers = "2.0.14"
 futures = "0.3.30"
 lazy_static = "1.4.0"
 fancy-regex = "0.11.0"

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -4,7 +4,10 @@ use alloy_json_abi::{Error, Event, EventParam, Function, JsonAbi, Param, StateMu
 
 use eyre::Result;
 use heimdall_common::{
-    ether::signatures::{ResolvedError, ResolvedLog},
+    ether::{
+        signatures::{ResolvedError, ResolvedLog},
+        types::{to_abi_string, to_components},
+    },
     utils::{hex::ToLowerHex, strings::encode_hex_reduced},
 };
 
@@ -85,14 +88,14 @@ pub fn build_abi(
                 Some(error) => (
                     error.name.clone(),
                     error
-                        .inputs
+                        .inputs()
                         .iter()
                         .enumerate()
                         .map(|(i, input)| Param {
                             name: format!("arg{i}"),
                             internal_type: None,
-                            ty: input.clone(),
-                            components: vec![],
+                            ty: to_abi_string(input),
+                            components: to_components(input),
                         })
                         .collect(),
                 ),
@@ -113,14 +116,14 @@ pub fn build_abi(
                 Some(event) => (
                     event.name.clone(),
                     event
-                        .inputs
+                        .inputs()
                         .iter()
                         .enumerate()
                         .map(|(i, input)| EventParam {
                             name: format!("arg{i}"),
                             internal_type: None,
-                            ty: input.clone(),
-                            components: vec![],
+                            ty: to_abi_string(input),
+                            components: to_components(input),
                             indexed: false,
                         })
                         .collect(),
@@ -129,6 +132,8 @@ pub fn build_abi(
             };
 
             let event = Event { name, inputs, anonymous: event_selector.is_zero() };
+
+            println!("event: {:#?}", event);
 
             abi.events.insert(event.name.clone(), vec![event]);
         });

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -54,14 +54,17 @@ pub fn build_abi(
                     name: format!("arg{i}"),
                     internal_type: None,
                     ty: match f.resolved_function {
-                        Some(ref sig) => sig.inputs[i].clone(),
+                        Some(ref sig) => to_abi_string(&sig.inputs()[i]),
                         None => arg
                             .potential_types()
                             .first()
                             .unwrap_or(&"bytes32".to_string())
                             .to_string(),
                     },
-                    components: vec![],
+                    components: match f.resolved_function {
+                        Some(ref sig) => to_components(&sig.inputs()[i]),
+                        None => vec![],
+                    },
                 })
                 .collect(),
             outputs: f

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -136,8 +136,6 @@ pub fn build_abi(
 
             let event = Event { name, inputs, anonymous: event_selector.is_zero() };
 
-            println!("event: {:#?}", event);
-
             abi.events.insert(event.name.clone(), vec![event]);
         });
 

--- a/crates/decompile/src/core/out/source.rs
+++ b/crates/decompile/src/core/out/source.rs
@@ -163,7 +163,7 @@ fn get_function_header(f: &AnalyzedFunction) -> Vec<String> {
                 format!(
                     "{} arg{i}",
                     match f.resolved_function {
-                        Some(ref sig) => sig.inputs[i].clone(),
+                        Some(ref sig) => sig.inputs()[i].to_string(),
                         None => arg
                             .potential_types()
                             .first()
@@ -241,7 +241,9 @@ fn get_event_and_error_declarations(
         let (name, inputs) = match all_resolved_logs
             .get(&encode_hex_reduced(*event_selector).replacen("0x", "", 1))
         {
-            Some(event) => (event.name.clone(), event.inputs.clone()),
+            Some(event) => {
+                (event.name.clone(), event.inputs().iter().map(|i| i.to_string()).collect())
+            }
             None => (
                 format!(
                     "Event_{}",
@@ -271,7 +273,9 @@ fn get_event_and_error_declarations(
         let (name, inputs) = match all_resolved_errors
             .get(&encode_hex_reduced(*error_selector).replacen("0x", "", 1))
         {
-            Some(error) => (error.name.clone(), error.inputs.clone()),
+            Some(error) => {
+                (error.name.clone(), error.inputs().iter().map(|i| i.to_string()).collect())
+            }
             None => (
                 format!(
                     "CustomError_{}",

--- a/crates/decompile/src/core/resolve.rs
+++ b/crates/decompile/src/core/resolve.rs
@@ -12,9 +12,8 @@ pub fn match_parameters(
     let mut matched_functions: Vec<ResolvedFunction> = Vec::new();
     for mut resolved_function in resolved_functions {
         trace!(
-            "checking function {}({}) against Unresolved_0x{}({})",
-            &resolved_function.name,
-            &resolved_function.inputs.join(","),
+            "checking function {} against Unresolved_0x{}({})",
+            &resolved_function.signature,
             &function.selector,
             &function
                 .arguments

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -17,7 +17,7 @@ heimdall-cache = { workspace = true }
 thiserror = "1.0.50"
 clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
-ethers = "2.0.4"
+ethers = "2.0.14"
 tracing = "0.1.40"
 eyre = "0.6.12"
 tokio = { version = "1", features = ["full"] }

--- a/crates/inspect/Cargo.toml
+++ b/crates/inspect/Cargo.toml
@@ -20,7 +20,7 @@ clap = { workspace = true, features = ["derive"] }
 derive_builder = "0.12.0"
 tracing = "0.1.40"
 eyre = "0.6.12"
-ethers = "2.0.4"
+ethers = "2.0.14"
 serde = { version = "1.0", features = ["derive"] }
 async-convert = "1.0.0"
 futures = "0.3.28"

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -15,7 +15,7 @@ async-openai = "0.10.0"
 clap = { workspace = true, features = ["derive"] }
 colored = "2"
 crossbeam-channel = "0.5.7"
-ethers = { version = "2.0.4", features = ["ipc", "ws"] }
+ethers = { version = "2.0.14", features = ["ipc", "ws"] }
 fancy-regex = "0.11.0"
 heimdall-cache = { workspace = true }
 indicatif = "0.17.0"
@@ -37,3 +37,4 @@ heimdall-common.workspace = true
 
 [features]
 step-tracing = []
+experimental = []

--- a/crates/vm/src/core/memory.rs
+++ b/crates/vm/src/core/memory.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "experimental")]
 use crate::ext::range_map::RangeMap;
 
+#[cfg(feature = "experimental")]
 use super::opcodes::WrappedOpcode;
 
+#[cfg(feature = "experimental")]
 pub type ByteTracker = RangeMap;
 
 /// The [`Memory`] struct represents the memory of an EVM.
@@ -9,6 +12,8 @@ pub type ByteTracker = RangeMap;
 pub struct Memory {
     /// Vector storing memory data
     pub memory: Vec<u8>,
+
+    #[cfg(feature = "experimental")]
     /// Byte-tracking facility, allowing bytes to be associated with the opcodes that last modified
     /// them
     pub bytes: ByteTracker,
@@ -23,7 +28,11 @@ impl Default for Memory {
 impl Memory {
     /// Creates a new [`Memory`] with an empty memory vector and empty byte tracker
     pub fn new() -> Memory {
-        Memory { memory: Vec::with_capacity(2048), bytes: ByteTracker::new() }
+        Memory {
+            memory: Vec::with_capacity(2048),
+            #[cfg(feature = "experimental")]
+            bytes: ByteTracker::new(),
+        }
     }
 
     /// Gets the current size of the memory in bytes.
@@ -103,9 +112,10 @@ impl Memory {
         offset: usize,
         size: usize,
         value: &[u8],
-        opcode: WrappedOpcode,
+        #[cfg(feature = "experimental")] opcode: WrappedOpcode,
     ) {
         self.store(offset, size, value);
+        #[cfg(feature = "experimental")]
         self.bytes.write(offset, size, opcode);
     }
 
@@ -177,6 +187,7 @@ impl Memory {
         }
     }
 
+    #[cfg(feature = "experimental")]
     /// Given an offset into memory, returns the opcode that last modified it (if it has been
     /// modified at all)
     ///

--- a/crates/vm/src/core/vm.rs
+++ b/crates/vm/src/core/vm.rs
@@ -839,9 +839,10 @@ impl VM {
                 let size = self.stack.pop()?.value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
-                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
-                let size: usize = size.try_into().unwrap_or(usize::MAX);
+                // Note: clamping to 8 words here, since we dont actually use the return data
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(8 * 32);
+                let offset: usize = offset.try_into().unwrap_or(8 * 32);
+                let size: usize = size.try_into().unwrap_or(8 * 32);
 
                 // clamp values to calldata length
                 let end_offset_clamped = (offset + size).min(self.calldata.len());
@@ -860,7 +861,13 @@ impl VM {
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(dest_offset, size, &value, operation);
+                self.memory.store_with_opcode(
+                    dest_offset,
+                    size,
+                    &value,
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // CODESIZE
@@ -877,9 +884,10 @@ impl VM {
                 let size = self.stack.pop()?.value;
 
                 // Safely convert U256 to usize
-                let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
-                let offset: usize = offset.try_into().unwrap_or(usize::MAX);
-                let size: usize = size.try_into().unwrap_or(usize::MAX);
+                // Note: clamping to 8 words here, since we dont actually use the return data
+                let dest_offset: usize = dest_offset.try_into().unwrap_or(8 * 32);
+                let offset: usize = offset.try_into().unwrap_or(8 * 32);
+                let size: usize = size.try_into().unwrap_or(8 * 32);
 
                 let value_offset_safe = (offset + size).min(self.bytecode.len());
                 let mut value =
@@ -895,7 +903,13 @@ impl VM {
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(dest_offset, size, &value, operation);
+                self.memory.store_with_opcode(
+                    dest_offset,
+                    size,
+                    &value,
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // GASPRICE
@@ -945,7 +959,13 @@ impl VM {
                     self.consume_gas(100);
                 }
 
-                self.memory.store_with_opcode(dest_offset, size, &value, operation);
+                self.memory.store_with_opcode(
+                    dest_offset,
+                    size,
+                    &value,
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // RETURNDATASIZE
@@ -973,7 +993,13 @@ impl VM {
                     3 * minimum_word_size + self.memory.expansion_cost(dest_offset, size);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(dest_offset, size, &value, operation);
+                self.memory.store_with_opcode(
+                    dest_offset,
+                    size,
+                    &value,
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // EXTCODEHASH and BLOCKHASH
@@ -1042,7 +1068,13 @@ impl VM {
                 let gas_cost = self.memory.expansion_cost(offset, 32);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(offset, 32, value.encode().as_slice(), operation);
+                self.memory.store_with_opcode(
+                    offset,
+                    32,
+                    value.encode().as_slice(),
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // MSTORE8
@@ -1057,7 +1089,13 @@ impl VM {
                 let gas_cost = self.memory.expansion_cost(offset, 1);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(offset, 1, &[value.encode()[31]], operation);
+                self.memory.store_with_opcode(
+                    offset,
+                    1,
+                    &[value.encode()[31]],
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // SLOAD
@@ -1189,7 +1227,13 @@ impl VM {
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
-                self.memory.store_with_opcode(dest_offset, size, &value, operation);
+                self.memory.store_with_opcode(
+                    dest_offset,
+                    size,
+                    &value,
+                    #[cfg(feature = "experimental")]
+                    operation,
+                );
             }
 
             // PC

--- a/crates/vm/src/ext/mod.rs
+++ b/crates/vm/src/ext/mod.rs
@@ -1,4 +1,6 @@
 pub mod exec;
 pub mod lexers;
-pub mod range_map;
 pub mod selectors;
+
+#[cfg(feature = "experimental")]
+pub mod range_map;

--- a/crates/vm/src/ext/range_map.rs
+++ b/crates/vm/src/ext/range_map.rs
@@ -49,7 +49,8 @@ impl RangeMap {
     ///  - split, if our range overwrites a subset that partitions it,
     ///  - shortened, if our range overwrites such that only one "end" of it is overwritten
     pub fn write(&mut self, offset: usize, size: usize, opcode: WrappedOpcode) {
-        let range: Range<usize> = Range { start: offset, end: offset + size - 1 };
+        let range: Range<usize> =
+            Range { start: offset, end: offset.saturating_add(size).saturating_sub(1) };
         let incumbents: Vec<Range<usize>> = self.affected_ranges(&range);
 
         if incumbents.is_empty() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #439 

## Solution

yes

also marks unused vm memory range_map as `--features experimental`, prevents some vm overflows
