### PR TITLE
fix(cfg): graph starts from offset `0x01` instead of `0x00`, prune redundant nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,6 +2225,7 @@ dependencies = [
  "lazy_static",
  "petgraph",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -14,6 +14,7 @@ exclude.workspace = true
 bench = false
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
 heimdall-config = { workspace = true }
 heimdall-common = { workspace = true }
 heimdall-cache = { workspace = true }

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -14,7 +14,6 @@ exclude.workspace = true
 bench = false
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
 heimdall-config = { workspace = true }
 heimdall-common = { workspace = true }
 heimdall-cache = { workspace = true }
@@ -30,3 +29,6 @@ alloy = { version = "0.3.3", features = ["full", "rpc-types-debug", "rpc-types-t
 
 heimdall-disassembler.workspace = true
 heimdall-vm.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/crates/cfg/src/core/graph.rs
+++ b/crates/cfg/src/core/graph.rs
@@ -46,7 +46,7 @@ pub fn build_cfg(
 
         cfg_node.push_str(&format!("{}\n", &assembly));
     }
-    
+
     // check if this node has been seen before
     if seen_nodes.contains(&cfg_node) {
         return Ok(());
@@ -73,7 +73,7 @@ pub fn build_cfg(
                 .last_instruction
                 .opcode ==
                 JUMPDEST,
-                seen_nodes,
+            seen_nodes,
         )?;
     }
 
@@ -82,8 +82,8 @@ pub fn build_cfg(
 
 #[cfg(test)]
 mod tests {
-    use crate::{cfg, CfgArgsBuilder};
     use super::*;
+    use crate::{cfg, CfgArgsBuilder};
     use tokio::test;
 
     #[test]
@@ -91,11 +91,11 @@ mod tests {
         let args = CfgArgsBuilder::new()
             .target("0x6080604052348015600e575f80fd5b50600436106030575f3560e01c80632125b65b146034578063b69ef8a8146044575b5f80fd5b6044603f3660046046565b505050565b005b5f805f606084860312156057575f80fd5b833563ffffffff811681146069575f80fd5b925060208401356001600160a01b03811681146083575f80fd5b915060408401356001600160e01b0381168114609d575f80fd5b80915050925092509256".to_string())
             .build()?;
-    
+
         let result = cfg(args).await?;
-    
+
         println!("Contract Cfg: {:#?}", result);
-    
+
         Ok(())
     }
 }

--- a/crates/cfg/src/core/graph.rs
+++ b/crates/cfg/src/core/graph.rs
@@ -25,7 +25,7 @@ pub fn build_cfg(
 
         let assembly = format!(
             "{} {} {}",
-            encode_hex_reduced(U256::from(operation.last_instruction.instruction)),
+            encode_hex_reduced(U256::from(operation.last_instruction.instruction - 1)), // start from 0x00
             opcode_name,
             if opcode_name.contains("PUSH") {
                 encode_hex_reduced(
@@ -67,4 +67,24 @@ pub fn build_cfg(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{cfg, CfgArgsBuilder};
+    use super::*;
+    use tokio::test;
+
+    #[test]
+    async fn test_build_cfg() -> Result<(), Box<dyn std::error::Error>> {
+        let args = CfgArgsBuilder::new()
+            .target("0x6080604052348015600e575f80fd5b50600436106030575f3560e01c80632125b65b146034578063b69ef8a8146044575b5f80fd5b6044603f3660046046565b505050565b005b5f805f606084860312156057575f80fd5b833563ffffffff811681146069575f80fd5b925060208401356001600160a01b03811681146083575f80fd5b915060408401356001600160e01b0381168114609d575f80fd5b80915050925092509256".to_string())
+            .build()?;
+    
+        let result = cfg(args).await?;
+    
+        println!("Contract Cfg: {:#?}", result);
+    
+        Ok(())
+    }
 }

--- a/crates/cfg/src/core/mod.rs
+++ b/crates/cfg/src/core/mod.rs
@@ -4,6 +4,7 @@ use alloy::primitives::Address;
 use eyre::eyre;
 use heimdall_common::{ether::compiler::detect_compiler, utils::strings::StringExt};
 use heimdall_vm::core::vm::VM;
+use std::collections::HashSet;
 
 use petgraph::{dot::Dot, Graph};
 use std::time::{Duration, Instant};
@@ -93,7 +94,8 @@ pub async fn cfg(args: CfgArgs) -> Result<CfgResult, Error> {
     let start_cfg_time = Instant::now();
     info!("building cfg for '{}' from symbolic execution trace", args.target.truncate(64));
     let mut contract_cfg = Graph::new();
-    build_cfg(&map, &mut contract_cfg, None, false)?;
+    let mut seen_nodes: HashSet<String> = HashSet::new();
+    build_cfg(&map, &mut contract_cfg, None, false, &mut seen_nodes)?;
     debug!("building cfg took {:?}", start_cfg_time.elapsed());
 
     debug!("cfg generated in {:?}", start_time.elapsed());

--- a/crates/common/src/ether/types.rs
+++ b/crates/common/src/ether/types.rs
@@ -69,10 +69,7 @@ fn extract_types_from_string(string: &str) -> Result<Vec<DynSolType>> {
                     let array_range = find_balanced_encapsulator(split, ('[', ']'))?;
 
                     let size = split[array_range].to_string();
-                    array_size = match size.parse::<usize>() {
-                        Ok(size) => Some(size),
-                        Err(_) => None,
-                    };
+                    array_size = size.parse::<usize>().ok();
                 }
             }
 
@@ -174,10 +171,7 @@ pub fn to_type(string: &str) -> DynSolType {
 
         let size = string[array_range].to_string();
 
-        array_size.push_back(match size.parse::<usize>() {
-            Ok(size) => Some(size),
-            Err(_) => None,
-        });
+        array_size.push_back(size.parse::<usize>().ok());
 
         string = string.replacen(&format!("[{}]", &size), "", 1);
     }

--- a/crates/core/tests/test_cfg.rs
+++ b/crates/core/tests/test_cfg.rs
@@ -57,7 +57,7 @@ mod integration_tests {
 
         let output = format!("{}", Dot::with_config(&result.graph, &[]));
 
-        for line in &[String::from("\"0x03a0 JUMPDEST \\l0x03a1 STOP \\l\"")] {
+        for line in &[String::from("\"0x039f JUMPDEST \\l0x03a0 STOP \\l\"")] {
             assert!(output.contains(line))
         }
     }

--- a/crates/vm/src/core/types.rs
+++ b/crates/vm/src/core/types.rs
@@ -35,10 +35,7 @@ pub fn to_type(string: &str) -> DynSolType {
 
         let size = string[array_range].to_string();
 
-        array_size.push_back(match size.parse::<usize>() {
-            Ok(size) => Some(size),
-            Err(_) => None,
-        });
+        array_size.push_back(size.parse::<usize>().ok());
 
         string = string.replacen(&format!("[{}]", &size), "", 1);
     }

--- a/crates/vm/src/core/vm.rs
+++ b/crates/vm/src/core/vm.rs
@@ -744,7 +744,7 @@ impl VM {
                 let result = keccak256(data);
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost = 6 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
@@ -850,7 +850,7 @@ impl VM {
                 }
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
@@ -892,7 +892,7 @@ impl VM {
                 }
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 
@@ -940,7 +940,7 @@ impl VM {
                 value.fill(0xff);
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost =
                     3 * minimum_word_size + self.memory.expansion_cost(dest_offset, size);
                 self.consume_gas(gas_cost);
@@ -979,7 +979,7 @@ impl VM {
                 value.fill(0xff);
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost =
                     3 * minimum_word_size + self.memory.expansion_cost(dest_offset, size);
                 self.consume_gas(gas_cost);
@@ -1211,7 +1211,7 @@ impl VM {
                 }
 
                 // consume dynamic gas
-                let minimum_word_size = ((size + 31) / 32) as u128;
+                let minimum_word_size = size.div_ceil(32) as u128;
                 let gas_cost = 3 * minimum_word_size + self.memory.expansion_cost(offset, size);
                 self.consume_gas(gas_cost);
 


### PR DESCRIPTION
## Motivation

Fix this issue: https://github.com/Jon-Becker/heimdall-rs/issues/499

## Solution

Subtract 1 from the index, which is `operation.last_instruction.instruction`, thereby shifting the overall offset to start from 0x00 (currently starting from 0x01).

I believe this approach is appropriate. Because the downstream program does not seem to use this offset, and this offset only serves as the destination for opcodes such as `JumpI` and related opcodes.

> Attention: The full testing has not been completed, so it is unclear whether it will affect other content. (I am not familiar with this repository). Therefore, please identify and test thoroughly.
