### PR TITLE
fix(bytecode): handle edge case where bytcode is exactly 20 bytes

### DIFF
--- a/crates/common/src/ether/bytecode.rs
+++ b/crates/common/src/ether/bytecode.rs
@@ -11,7 +11,9 @@ use std::fs;
 pub async fn get_bytecode_from_target(target: &str, rpc_url: &str) -> Result<Vec<u8>> {
     // If the target is an address, fetch the bytecode from the RPC provider.
     if let Ok(address) = target.parse::<Address>() {
-        return get_code(address, rpc_url).await;
+        if let Ok(bytecode) = get_code(address, rpc_url).await {
+            return Ok(bytecode);
+        }
     }
 
     // If the target is not an address, it could be bytecode or a file path.

--- a/crates/common/src/ether/bytecode.rs
+++ b/crates/common/src/ether/bytecode.rs
@@ -6,6 +6,7 @@ use super::rpc::get_code;
 use alloy::primitives::{bytes::Bytes, Address};
 use eyre::{eyre, Result};
 use std::fs;
+use tracing::debug;
 
 /// Given a target, return bytecode of the target.
 pub async fn get_bytecode_from_target(target: &str, rpc_url: &str) -> Result<Vec<u8>> {
@@ -14,6 +15,10 @@ pub async fn get_bytecode_from_target(target: &str, rpc_url: &str) -> Result<Vec
         if let Ok(bytecode) = get_code(address, rpc_url).await {
             return Ok(bytecode);
         }
+
+        debug!(
+            "failed to fetch bytecode from RPC provider. attempting to decode target as bytecode"
+        );
     }
 
     // If the target is not an address, it could be bytecode or a file path.

--- a/crates/common/src/ether/rpc.rs
+++ b/crates/common/src/ether/rpc.rs
@@ -9,7 +9,7 @@ use alloy::{
         Filter, FilterBlockOption, FilterSet, Log, Transaction,
     },
 };
-use eyre::{OptionExt, Result};
+use eyre::{bail, OptionExt, Result};
 use heimdall_cache::with_cache;
 use tokio_retry::{strategy::ExponentialBackoff, Retry};
 
@@ -59,6 +59,11 @@ pub async fn latest_block_number(rpc_url: &str) -> Result<u128> {
 /// // assert!(bytecode.is_ok());
 /// ```
 pub async fn get_code(contract_address: Address, rpc_url: &str) -> Result<Vec<u8>> {
+    // if rpc_url is empty, return an error
+    if rpc_url.is_empty() {
+        bail!("cannot get_code, rpc_url is empty");
+    }
+
     Retry::spawn(ExponentialBackoff::from_millis(50).take(2), || async {
         let chain_id = chain_id(rpc_url).await.unwrap_or(1);
         with_cache(&format!("contract.{}.{}", &chain_id, &contract_address), || async {

--- a/crates/core/tests/test_disassemble.rs
+++ b/crates/core/tests/test_disassemble.rs
@@ -42,6 +42,24 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn test_disassemble_20_byte_non_address() {
+        let bytecode = "608060405234801561000f575f5ffd5b50600400";
+        let expected = String::from("000000 PUSH1 80\n000002 PUSH1 40\n000004 MSTORE \n000005 CALLVALUE \n000006 DUP1 \n000007 ISZERO \n000008 PUSH2 000f\n00000b JUMPI \n00000c PUSH0 \n00000d PUSH0 \n00000e REVERT \n00000f JUMPDEST \n000010 POP \n000011 PUSH1 04\n000013 STOP \n");
+
+        let assembly = disassemble(DisassemblerArgs {
+            target: bytecode.to_owned(),
+            rpc_url: String::from(""),
+            decimal_counter: false,
+            name: String::from(""),
+            output: String::from(""),
+        })
+        .await
+        .expect("failed to disassemble");
+
+        assert_eq!(expected, assembly);
+    }
+
+    #[tokio::test]
     async fn test_disassemble_with_custom_output() {
         let bytecode = "366000600037611000600036600073";
         let expected = String::from("0 CALLDATASIZE \n1 PUSH1 00\n3 PUSH1 00\n5 CALLDATACOPY \n6 PUSH2 1000\n9 PUSH1 00\n11 CALLDATASIZE \n12 PUSH1 00\n");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

cc @chen4903 

we treat 20-byte strings as an address, but if fetching bytecode fails we can return the bytes and assume they are disassembling/decompiling some exactly 20 byte contract

the reason i had to remove the code in your PR was just that the .unwrap() on the decode_hex() call could fail, and was making one of the tests unhappy. i believe this approach is more robust as well

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
