### PR TITLE
feat(decompile): deadcode postprocessor pass

### DIFF
--- a/crates/decompile/src/utils/postprocessors/deadcode.rs
+++ b/crates/decompile/src/utils/postprocessors/deadcode.rs
@@ -21,18 +21,6 @@ struct Assignment {
     var_name: String,
 }
 
-/// Removes empty lines from the function logic.
-///
-/// This pass should run last, after all other postprocessors have completed,
-/// to clean up lines that were cleared by other passes.
-pub(crate) fn remove_empty_lines(
-    function: &mut AnalyzedFunction,
-    _state: &mut PostprocessorState,
-) -> Result<(), Error> {
-    function.logic.retain(|line| !line.trim().is_empty());
-    Ok(())
-}
-
 /// Eliminates dead variable assignments from the function logic.
 ///
 /// A variable assignment is considered dead if:

--- a/crates/decompile/src/utils/postprocessors/empty_lines.rs
+++ b/crates/decompile/src/utils/postprocessors/empty_lines.rs
@@ -1,0 +1,13 @@
+use crate::{core::postprocess::PostprocessorState, interfaces::AnalyzedFunction, Error};
+
+/// Removes empty lines from the function logic.
+///
+/// This pass should run last, after all other postprocessors have completed,
+/// to clean up lines that were cleared by other passes.
+pub(crate) fn remove_empty_lines(
+    function: &mut AnalyzedFunction,
+    _state: &mut PostprocessorState,
+) -> Result<(), Error> {
+    function.logic.retain(|line| !line.trim().is_empty());
+    Ok(())
+}

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -1,9 +1,10 @@
-use crate::{core::postprocess::PostprocessorState, Error};
+use crate::{core::postprocess::PostprocessorState, interfaces::AnalyzedFunction, Error};
 
 // import postprocessors
 mod arithmetic;
 mod bitwise;
 mod deadcode;
+mod empty_lines;
 mod memory;
 mod storage;
 mod transient;
@@ -12,31 +13,59 @@ mod variable;
 // re-export postprocessors
 pub(crate) use arithmetic::arithmetic_postprocessor;
 pub(crate) use bitwise::bitwise_mask_postprocessor;
-pub(crate) use deadcode::{eliminate_dead_variables, remove_empty_lines};
+pub(crate) use deadcode::eliminate_dead_variables;
+pub(crate) use empty_lines::remove_empty_lines;
 pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
 pub(crate) use transient::transient_postprocessor;
 pub(crate) use variable::variable_postprocessor;
 
-/// A heuristic is a function that takes a function and a state and modifies the function based on
-/// the state
-pub(crate) struct Postprocessor {
-    implementation: fn(&mut String, &mut PostprocessorState) -> Result<(), Error>,
+/// A line-level postprocessor function signature
+type LinePostprocessor = fn(&mut String, &mut PostprocessorState) -> Result<(), Error>;
+
+/// A function-level postprocessor function signature
+type FunctionPostprocessor =
+    fn(&mut AnalyzedFunction, &mut PostprocessorState) -> Result<(), Error>;
+
+/// A pass operates on the entire function's logic.
+///
+/// Passes are registered in order and executed sequentially. There are two types:
+/// - `LineLevel`: Runs a set of postprocessors on each line
+/// - `FunctionLevel`: Runs a transformation on the entire function
+pub(crate) enum Pass {
+    /// Runs a set of line-level postprocessors on each line sequentially
+    LineLevel { postprocessors: Vec<LinePostprocessor> },
+    /// Runs a single function-level transformation
+    FunctionLevel { transform: FunctionPostprocessor },
 }
 
-impl Postprocessor {
-    pub(crate) fn new(
-        implementation: fn(&mut String, &mut PostprocessorState) -> Result<(), Error>,
-    ) -> Self {
-        Self { implementation }
+impl Pass {
+    /// Create a new line-level pass with the given postprocessors
+    pub(crate) fn line_level(postprocessors: Vec<LinePostprocessor>) -> Self {
+        Self::LineLevel { postprocessors }
     }
 
-    /// Run the postprocessor implementation on the given function
+    /// Create a new function-level pass with the given transformation
+    pub(crate) fn function_level(transform: FunctionPostprocessor) -> Self {
+        Self::FunctionLevel { transform }
+    }
+
+    /// Run the pass on the given function
     pub(crate) fn run(
         &self,
-        line: &mut String,
+        function: &mut AnalyzedFunction,
         state: &mut PostprocessorState,
     ) -> Result<(), Error> {
-        (self.implementation)(line, state)
+        match self {
+            Pass::LineLevel { postprocessors } => {
+                for line in function.logic.iter_mut() {
+                    for postprocessor in postprocessors {
+                        postprocessor(line, state)?;
+                    }
+                }
+                Ok(())
+            }
+            Pass::FunctionLevel { transform } => transform(function, state),
+        }
     }
 }


### PR DESCRIPTION
## What changed? Why?

refactored the postprocessor architecture to support both line-level and function-level passes. the `Postprocessor` struct is now replaced with a `Pass` enum that can handle two types of transformations:
- `LineLevel`: runs a set of postprocessors sequentially on each line of function logic
- `FunctionLevel`: runs a single transformation on the entire function

this refactoring enables new capabilities like the dead code elimination pass, which requires analyzing the entire function to determine which variable assignments are unused.

added two new postprocessor passes:
- `eliminate_dead_variables`: removes variable assignments that are never used or are overwritten before use. includes comprehensive tests for various scenarios (simple dead variables, overwrites, side effects, etc.)
- `remove_empty_lines`: cleans up empty lines left by other passes

## Key files to review

- `crates/decompile/src/utils/postprocessors/mod.rs` - refactored `Postprocessor` to `Pass` enum
- `crates/decompile/src/core/postprocess.rs` - updated orchestrator to use new pass system
- `crates/decompile/src/utils/postprocessors/deadcode.rs` - new dead code elimination logic
- `crates/decompile/src/utils/postprocessors/empty_lines.rs` - new empty line removal logic

## How has it been tested?

- unit tests