### PR TITLE
feat: add aarch64 support for macos and linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
           - os: macos-latest
             artifact_name: heimdall
             asset_name: heimdall-macos-amd64
+          - os: macos-14
+            artifact_name: heimdall
+            asset_name: heimdall-macos-arm64
+          - os: ubuntu-24.04-arm
+            artifact_name: heimdall
+            asset_name: heimdall-linux-arm64
 
     steps:
     - uses: actions/checkout@v2

--- a/bifrost/bifrost
+++ b/bifrost/bifrost
@@ -116,14 +116,16 @@ main() {
         echo "bifrost: fetching binary."
 
         # download the binary
+        ARCH=$(uname -m)
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            ensure curl -k -L -s --compressed "https://github.com/Jon-Becker/heimdall-rs/releases/download/$TARGET_VERSION/heimdall-linux-amd64" -o heimdall
+            [[ "$ARCH" == "aarch64" ]] && ASSET="heimdall-linux-arm64" || ASSET="heimdall-linux-amd64"
         elif [[ "$OSTYPE" == "darwin"* ]]; then
-            ensure curl -k -L -s --compressed "https://github.com/Jon-Becker/heimdall-rs/releases/download/$TARGET_VERSION/heimdall-macos-amd64" -o heimdall
+            [[ "$ARCH" == "arm64" ]] && ASSET="heimdall-macos-arm64" || ASSET="heimdall-macos-amd64"
         else
             echo "bifrost: unsupported operating system: $OSTYPE"
             exit 1
         fi
+        ensure curl -k -L -s --compressed "https://github.com/Jon-Becker/heimdall-rs/releases/download/$TARGET_VERSION/$ASSET" -o heimdall
         echo "bifrost: installing binary."
 
         # make the binary executable


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## What changed? Why?

Adds native aarch64 support for macOS (Apple Silicon) and Linux arm64 (tested on macOS via Docker, should work on other architectures as no native Rust libs are used).


- `.github/workflows/release.yml`: adds `macos-14` and `ubuntu-24.04-arm` 
  matrix entries, producing `heimdall-macos-arm64` and `heimdall-linux-arm64` 
  release artifacts
- `bifrost/bifrost`: fixes `--binary` flag to detect host architecture via 
  `uname -m` and download the correct asset instead of always defaulting to amd64


## Notes to reviewers

- `.github/workflows/release.yml` : 4 lines added to the matrix
- `bifrost/bifrost` : binary download block updated with arch detection


## How has it been tested?

All offline and RPC dependent commands (disassemble, decode, cache, config, decompile, cfg, inspect, dump) were tested on macOS arm64 and on docker version for the linux release 
