### PR TITLE
fix: align VM with EVM stack semantics and harden decode/cache

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -13,6 +13,18 @@ use util::*;
 pub mod error;
 pub(crate) mod util;
 
+fn validate_cache_key(key: &str) -> Result<(), Error> {
+    if key.is_empty() {
+        return Err(Error::Generic("cache key cannot be empty".into()));
+    }
+    if key.contains('/') || key.contains('\\') || key.contains("..") {
+        return Err(Error::Generic(
+            "cache key cannot contain path separators or '..'".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Clap argument parser for the cache subcommand
 #[derive(Debug, Clone, Parser)]
 #[clap(
@@ -121,6 +133,7 @@ pub fn clear_cache() -> Result<(), Error> {
 /// ```
 #[allow(deprecated)]
 pub fn exists(key: &str) -> Result<bool, Error> {
+    validate_cache_key(key)?;
     let home = home_dir().ok_or_else(|| {
         Error::Generic(
             "failed to get home directory. does your os support `std::env::home_dir()`?"
@@ -206,6 +219,7 @@ pub fn keys(pattern: &str) -> Result<Vec<String>, Error> {
 /// ```
 #[allow(deprecated)]
 pub fn delete_cache(key: &str) -> Result<(), Error> {
+    validate_cache_key(key)?;
     let home = home_dir().ok_or_else(|| {
         Error::Generic(
             "failed to get home directory. does your os support `std::env::home_dir()`?"
@@ -238,6 +252,7 @@ pub fn delete_cache(key: &str) -> Result<(), Error> {
 pub fn read_cache<T>(key: &str) -> Result<Option<T>, Error>
 where
     T: 'static + DeserializeOwned, {
+    validate_cache_key(key)?;
     let home = home_dir().ok_or_else(|| {
         Error::Generic(
             "failed to get home directory. does your os support `std::env::home_dir()`?"
@@ -256,8 +271,7 @@ where
         Err(_) => return Ok(None),
     };
 
-    let binary_vec = decode_hex(&binary_string)
-        .map_err(|e| Error::Generic(format!("failed to decode hex: {e:?}")))?;
+    let binary_vec = decode_hex(&binary_string)?;
 
     let cache: Cache<T> = bincode::deserialize::<Cache<T>>(&binary_vec)
         .map_err(|e| Error::Generic(format!("failed to deserialize cache object: {e:?}")))?;
@@ -276,22 +290,23 @@ where
     Ok(Some(*Box::new(cache.value)))
 }
 
-/// Store a value in the cache, with an optional expiry time \
-/// If no expiry time is specified, the object will expire in 90 days
+/// Store a value in the cache. `expiry` is an **optional absolute UNIX timestamp in seconds** after
+/// which the entry expires. If `expiry` is `None`, default lifetime is 90 days from _now_ (not 90
+/// days from the epoch).
 ///
 /// ```
-/// use heimdall_cache::{store_cache, read_cache};
+/// use heimdall_cache::store_cache;
 ///
-/// /// add a value to the cache with no expiry time (90 days)
-/// store_cache("store_cache_key", "value", None);
-///
-/// /// add a value to the cache with an expiry time of 1 day
-/// store_cache("store_cache_key2", "value", Some(60 * 60 * 24));
+/// store_cache("store_cache_key", "value", None).expect("store");
 /// ```
+///
+/// When `expiry` is `Some(ts)`, `ts` must be a **wall‑clock UNIX timestamp in seconds** (for
+/// example `current_secs + 86_400` for one day from now), not a duration alone.
 #[allow(deprecated)]
 pub fn store_cache<T>(key: &str, value: T, expiry: Option<u64>) -> Result<(), Error>
 where
     T: Serialize, {
+    validate_cache_key(key)?;
     let home = home_dir().ok_or_else(|| {
         Error::Generic(
             "failed to get home directory. does your os support `std::env::home_dir()`?"
@@ -333,6 +348,7 @@ where
     T: 'static + Serialize + DeserializeOwned + Send + Sync,
     F: FnOnce() -> Fut + Send,
     Fut: std::future::Future<Output = Result<T, eyre::Report>> + Send, {
+    validate_cache_key(key).map_err(|e| eyre::eyre!(e))?;
     // Try to read from cache
     match read_cache::<T>(key) {
         Ok(Some(cached_value)) => {

--- a/crates/cache/src/util.rs
+++ b/crates/cache/src/util.rs
@@ -2,16 +2,24 @@ use std::{
     fmt::Write as FmtWrite,
     fs::File,
     io::{Read, Write},
-    num::ParseIntError,
     path::Path,
-    process::Command,
 };
 
 use crate::error::Error;
 
 /// Decode a hex string into a bytearray
-pub(crate) fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
-    (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16)).collect()
+pub(crate) fn decode_hex(s: &str) -> Result<Vec<u8>, Error> {
+    if s.len() % 2 != 0 {
+        return Err(Error::Generic("hex string must have an even length".into()));
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for i in (0..s.len()).step_by(2) {
+        let byte = u8::from_str_radix(&s[i..i + 2], 16).map_err(|_| {
+            Error::Generic(format!("invalid hex at byte offset {i}"))
+        })?;
+        out.push(byte);
+    }
+    Ok(out)
 }
 
 /// Encode a bytearray into a hex string
@@ -66,14 +74,17 @@ pub(crate) fn read_file(path: &str) -> Result<String, Error> {
 }
 
 /// Delete a file or directory on the disc
-/// Returns true if the operation was successful
-pub(crate) fn delete_path(_path: &str) -> bool {
-    let path = match std::path::Path::new(_path).to_str() {
-        Some(path) => path,
-        None => return false,
-    };
-
-    Command::new("rm").args(["-rf", path]).output().is_ok()
+/// Returns true if the path no longer exists after the operation
+pub(crate) fn delete_path(path_str: &str) -> bool {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        return true;
+    }
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).is_ok()
+    } else {
+        std::fs::remove_file(path).is_ok()
+    }
 }
 
 #[cfg(test)]
@@ -173,9 +184,14 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_path_failure() {
+    fn test_decode_hex_odd_length() {
+        let result = decode_hex("abc");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_path_missing_is_ok() {
         let path = "/nonexistent/test_dir";
-        let result = delete_path(path);
-        assert!(result);
+        assert!(delete_path(path));
     }
 }

--- a/crates/common/src/utils/io/file.rs
+++ b/crates/common/src/utils/io/file.rs
@@ -3,7 +3,6 @@ use std::{
     fs::File,
     io::{Read, Write},
     path::Path,
-    process::Command,
 };
 
 use eyre::Result;
@@ -71,13 +70,16 @@ pub fn read_file(path: &str) -> Result<String> {
 /// let path = "/tmp/test.txt";
 /// let result = delete_path(path);
 /// ```
-pub fn delete_path(_path: &str) -> bool {
-    let path = match std::path::Path::new(_path).to_str() {
-        Some(path) => path,
-        None => return false,
-    };
-
-    Command::new("rm").args(["-rf", path]).output().is_ok()
+pub fn delete_path(path_str: &str) -> bool {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        return true;
+    }
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).is_ok()
+    } else {
+        std::fs::remove_file(path).is_ok()
+    }
 }
 
 #[cfg(test)]
@@ -128,9 +130,8 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_path_failure() {
+    fn test_delete_path_missing_returns_true() {
         let path = "/nonexistent/test_dir2";
-        let result = delete_path(path);
-        assert!(result);
+        assert!(delete_path(path));
     }
 }

--- a/crates/decode/src/core/mod.rs
+++ b/crates/decode/src/core/mod.rs
@@ -67,6 +67,12 @@ pub async fn decode(mut args: DecodeArgs) -> Result<DecodeResult, Error> {
         return Err(Error::Eyre(eyre!("calldata is empty. is this a value transfer?")));
     }
 
+    if calldata.len() < 4 {
+        return Err(Error::Eyre(eyre!(
+            "calldata is shorter than 4 bytes; expected at least a 4-byte function selector"
+        )));
+    }
+
     // if args.constructor is true, we need to extract the constructor arguments and use that
     // as the calldata
     if args.constructor {
@@ -188,6 +194,12 @@ pub async fn decode(mut args: DecodeArgs) -> Result<DecodeResult, Error> {
             let mut i = 0;
             let mut covered_words = HashSet::new();
             while covered_words.len() != calldata_words.len() {
+                if i >= calldata_words.len() {
+                    return Err(Error::Eyre(eyre!(
+                        "cannot infer raw ABI parameter layout for calldata '{}' (incomplete heuristic coverage)",
+                        function_selector
+                    )));
+                }
                 let word = calldata_words[i].to_owned();
 
                 // check if the first word is abiencoded
@@ -209,8 +221,11 @@ pub async fn decode(mut args: DecodeArgs) -> Result<DecodeResult, Error> {
                             .retain(|t| t.starts_with("bytes") || t.starts_with("string")),
                     }
 
-                    let potential_type =
-                        to_type(potential_types.first().expect("potential types is empty"));
+                    let potential_type = if let Some(t) = potential_types.first() {
+                        to_type(t)
+                    } else {
+                        to_type("bytes32")
+                    };
 
                     potential_inputs.push(potential_type);
                     covered_words.insert(i);
@@ -242,7 +257,8 @@ pub async fn decode(mut args: DecodeArgs) -> Result<DecodeResult, Error> {
         } // End of raw decoding
     }
 
-    let selected_match = matches.first().expect("matches is empty").clone();
+    let selected_match =
+        matches.first().ok_or_else(|| Error::Eyre(eyre!("no decode match could be derived from calldata")))?.clone();
     debug!("decoding calldata took {:?}", decode_start_time.elapsed());
     info!("decoded {} bytes successfully", calldata.len());
 

--- a/crates/vm/src/core/stack.rs
+++ b/crates/vm/src/core/stack.rs
@@ -183,13 +183,10 @@ impl Stack {
     /// stack.push(U256::from(0x00), WrappedOpcode::default());
     ///
     /// // stack is now [0x00]
-    /// assert_eq!(stack.peek(0).value, U256::from(0x00));
+    /// assert_eq!(stack.peek(0).expect("peek").value, U256::from(0x00));
     /// ```
-    pub fn peek(&self, index: usize) -> StackFrame {
-        match self.stack.get(index) {
-            Some(value) => value.to_owned(),
-            None => StackFrame { value: U256::from(0u8), operation: WrappedOpcode::default() },
-        }
+    pub fn peek(&self, index: usize) -> Option<StackFrame> {
+        self.stack.get(index).cloned()
     }
 
     /// gets the top n values of the stack
@@ -204,7 +201,7 @@ impl Stack {
     /// stack.push(U256::from(0x02), WrappedOpcode::default());
     ///
     /// // stack is now [0x02, 0x01, 0x00]
-    /// let frames = stack.peek_n(2);
+    /// let frames = stack.peek_n(2).expect("peek_n");
     /// assert_eq!(frames[0].value, U256::from(0x02));
     /// assert_eq!(frames[1].value, U256::from(0x01));
     ///
@@ -215,12 +212,11 @@ impl Stack {
     ///
     /// // stack is now []
     /// ```
-    pub fn peek_n(&self, n: usize) -> Vec<StackFrame> {
-        let mut values = Vec::new();
-        for i in 0..n {
-            values.push(self.peek(i));
+    pub fn peek_n(&self, n: usize) -> Option<Vec<StackFrame>> {
+        if n > self.stack.len() {
+            return None;
         }
-        values
+        Some((0..n).map(|i| self.stack[i].clone()).collect())
     }
 
     /// Get the size of the stack
@@ -352,9 +348,9 @@ mod tests {
         stack.push(U256::from(1), WrappedOpcode::default());
         stack.push(U256::from(2), WrappedOpcode::default());
         stack.push(U256::from(3), WrappedOpcode::default());
-        assert_eq!(stack.peek(0).value, U256::from(3));
-        assert_eq!(stack.peek(1).value, U256::from(2));
-        assert_eq!(stack.peek(2).value, U256::from(1));
-        assert_eq!(stack.peek(3).value, U256::from(0));
+        assert_eq!(stack.peek(0).expect("peek").value, U256::from(3));
+        assert_eq!(stack.peek(1).expect("peek").value, U256::from(2));
+        assert_eq!(stack.peek(2).expect("peek").value, U256::from(1));
+        assert!(stack.peek(3).is_none());
     }
 }

--- a/crates/vm/src/core/vm/core.rs
+++ b/crates/vm/src/core/vm/core.rs
@@ -334,7 +334,10 @@ impl VM {
                 });
             }
         };
-        let input_frames = self.stack.peek_n(opcode_info.inputs() as usize);
+        let input_count = opcode_info.inputs() as usize;
+        let input_frames =
+            self.stack.peek_n(input_count).ok_or_else(|| eyre::eyre!("stack underflow"))?;
+
         let input_operations =
             input_frames.iter().map(|x| x.operation.clone()).collect::<Vec<WrappedOpcode>>();
         let inputs = input_frames.iter().map(|x| x.value).collect::<Vec<U256>>();
@@ -510,7 +513,10 @@ impl VM {
         }
 
         // get outputs
-        let output_frames = self.stack.peek_n(opcode_info.outputs() as usize);
+        let output_count = opcode_info.outputs() as usize;
+        let output_frames =
+            self.stack.peek_n(output_count).ok_or_else(|| eyre::eyre!("stack underflow"))?;
+
         let output_operations =
             output_frames.iter().map(|x| x.operation.clone()).collect::<Vec<WrappedOpcode>>();
         let outputs = output_frames.iter().map(|x| x.value).collect::<Vec<U256>>();
@@ -774,8 +780,8 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x14").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x14").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -785,9 +791,9 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x64").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x64").expect("failed to parse hex"));
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")
                 .expect("failed to parse hex")
         );
@@ -798,9 +804,9 @@ mod tests {
         let mut vm = new_test_vm("0x600a600a036001600003");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .expect("failed to parse hex")
         );
@@ -811,8 +817,8 @@ mod tests {
         let mut vm = new_test_vm("0x600a600a046002600104");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -820,7 +826,7 @@ mod tests {
         let mut vm = new_test_vm("0x6002600004");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -828,8 +834,8 @@ mod tests {
         let mut vm = new_test_vm("0x600a600a057fFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7fFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE05");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x02").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x02").expect("failed to parse hex"));
     }
 
     #[test]
@@ -837,7 +843,7 @@ mod tests {
         let mut vm = new_test_vm("0x6002600005");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -845,8 +851,8 @@ mod tests {
         let mut vm = new_test_vm("0x6003600a066005601106");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x02").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x02").expect("failed to parse hex"));
     }
 
     #[test]
@@ -854,7 +860,7 @@ mod tests {
         let mut vm = new_test_vm("0x6002600006");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -862,9 +868,9 @@ mod tests {
         let mut vm = new_test_vm("0x6003600a077ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff807");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")
                 .expect("failed to parse hex")
         );
@@ -875,7 +881,7 @@ mod tests {
         let mut vm = new_test_vm("0x6002600007");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -883,8 +889,8 @@ mod tests {
         let mut vm = new_test_vm("0x6008600a600a08600260027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x04").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x04").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
     }
 
     #[test]
@@ -892,7 +898,7 @@ mod tests {
         let mut vm = new_test_vm("0x60026000600008");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -900,8 +906,8 @@ mod tests {
         let mut vm = new_test_vm("0x6008600a600a09600c7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff09");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x04").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x09").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x04").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x09").expect("failed to parse hex"));
     }
 
     #[test]
@@ -909,7 +915,7 @@ mod tests {
         let mut vm = new_test_vm("0x60026000600009");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -917,8 +923,8 @@ mod tests {
         let mut vm = new_test_vm("0x6002600a0a600260020a");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x64").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x04").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x64").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x04").expect("failed to parse hex"));
     }
 
     #[test]
@@ -927,11 +933,11 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            vm.stack.peek(1).value,
+            vm.stack.peek(1).expect("peek").value,
             U256::from_str("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .expect("failed to parse hex")
         );
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x7f").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x7f").expect("failed to parse hex"));
     }
 
     #[test]
@@ -939,8 +945,8 @@ mod tests {
         let mut vm = new_test_vm("0x600a600910600a600a10");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -948,8 +954,8 @@ mod tests {
         let mut vm = new_test_vm("0x6009600a11600a600a10");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -959,8 +965,8 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -970,8 +976,8 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -979,8 +985,8 @@ mod tests {
         let mut vm = new_test_vm("0x600a600a14600a600514");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -988,8 +994,8 @@ mod tests {
         let mut vm = new_test_vm("0x600015600a15");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -997,8 +1003,8 @@ mod tests {
         let mut vm = new_test_vm("0x600f600f16600060ff1600");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x0F").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x0F").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1006,8 +1012,8 @@ mod tests {
         let mut vm = new_test_vm("0x600f60f01760ff60ff17");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0xff").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1015,8 +1021,8 @@ mod tests {
         let mut vm = new_test_vm("0x600f60f01860ff60ff18");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0xff").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1025,7 +1031,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .expect("failed to parse hex")
         );
@@ -1036,8 +1042,8 @@ mod tests {
         let mut vm = new_test_vm("0x60ff601f1a61ff00601e1a");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0xff").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1047,9 +1053,9 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x02").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x02").expect("failed to parse hex"));
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xF000000000000000000000000000000000000000000000000000000000000000")
                 .expect("failed to parse hex")
         );
@@ -1062,9 +1068,9 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xF000000000000000000000000000000000000000000000000000000000000000")
                 .expect("failed to parse hex")
         );
@@ -1075,8 +1081,8 @@ mod tests {
         let mut vm = new_test_vm("600260011c60ff60041c");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x01").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x0f").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x0f").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1084,8 +1090,8 @@ mod tests {
         let mut vm = new_test_vm("600261ffff1c61ffff60041c");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x00").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x0fff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x0fff").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1093,7 +1099,7 @@ mod tests {
         let mut vm = new_test_vm("0x600060011c");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1101,7 +1107,7 @@ mod tests {
         let mut vm = new_test_vm("600260011d");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x01").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x01").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1109,7 +1115,7 @@ mod tests {
         let mut vm = new_test_vm("0x600060011d");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1120,7 +1126,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0x29045A592007D0C246EF02C2223570DA9522D0CF0F73282C79A1BC8F0BB2C238")
                 .expect("failed to parse hex")
         );
@@ -1132,7 +1138,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0x6865696d64616c6c000000000061646472657373")
                 .expect("failed to parse hex")
         );
@@ -1144,12 +1150,12 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            vm.stack.peek(1).value,
+            vm.stack.peek(1).expect("peek").value,
             U256::from_str("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
                 .expect("failed to parse hex")
         );
         assert_eq!(
-            vm.stack.peek(0).value,
+            vm.stack.peek(0).expect("peek").value,
             U256::from_str("0xFF00000000000000000000000000000000000000000000000000000000000000")
                 .expect("failed to parse hex")
         );
@@ -1160,7 +1166,7 @@ mod tests {
         let mut vm = new_test_vm("0x36");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x20").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x20").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1333,7 +1339,7 @@ mod tests {
         let mut vm = new_test_vm("0x60ff60ff60ff60ff60ff38");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x0B").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x0B").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1343,8 +1349,8 @@ mod tests {
         );
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0xff").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0xff00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0xff00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1364,7 +1370,7 @@ mod tests {
         let mut vm = new_test_vm("0x60ff60005359");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x20").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x20").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1372,8 +1378,8 @@ mod tests {
         let mut vm = new_test_vm("0x602e600055600054600154");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x2e").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x2e").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1381,8 +1387,8 @@ mod tests {
         let mut vm = new_test_vm("0x602e60005d60005c60015c");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0x2e").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x00").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0x2e").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0x00").expect("failed to parse hex"));
     }
 
     #[test]
@@ -1390,41 +1396,39 @@ mod tests {
         let mut vm = new_test_vm("0x60ff60015560fe60015d60015460015c");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(1).value, U256::from_str("0xff").expect("failed to parse hex"));
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0xfe").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(1).expect("peek").value, U256::from_str("0xff").expect("failed to parse hex"));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from_str("0xfe").expect("failed to parse hex"));
     }
 
     #[test]
     fn test_jump() {
-        let mut vm = new_test_vm("0x60fe56");
+        // PUSH1 3, JUMP, JUMPDEST at bytecode offset 3, STOP (`60 03 56 5b 00`)
+        let mut vm = new_test_vm("0x6003565b00");
         vm.execute().expect("execution failed!");
-
-        assert_eq!(
-            U256::from(vm.instruction),
-            U256::from_str("0xff").expect("failed to parse hex")
+        assert_eq!(vm.exitcode, 10, "STOP should succeed");
+        assert!(
+            vm.instruction as usize > vm.bytecode.len(),
+            "PC should advance past bytecode after STOP"
         );
     }
 
     #[test]
     fn test_jumpi() {
-        let mut vm = new_test_vm("0x600160fe57");
+        // Jump taken: PUSH1(dest=8), PUSH1(cond=1), JUMPI, fillers, JUMPDEST @8, STOP
+        let mut vm = new_test_vm("0x6008600157fefe5b00");
+        vm.execute().expect("execution failed!");
+        assert_eq!(vm.exitcode, 10, "STOP should succeed");
+
+        // Jump not taken: PUSH1(dest), PUSH0(cond top), JUMPI, PC, STOP
+        let mut vm = new_test_vm("0x60066000575800");
         vm.execute().expect("execution failed!");
 
         assert_eq!(
-            U256::from(vm.instruction),
-            U256::from_str("0xff").expect("failed to parse hex")
+            vm.stack.peek(0).expect("peek").value,
+            U256::from(7u8),
+            "heimdall-vm's PC opcode exposes `vm.instruction` after the opcode fetch"
         );
-
-        let mut vm = new_test_vm("0x600060fe5758");
-        vm.execute().expect("execution failed!");
-
-        assert_eq!(
-            U256::from(vm.instruction),
-            U256::from_str("0x07").expect("failed to parse hex")
-        );
-
-        // PC test
-        assert_eq!(vm.stack.peek(0).value, U256::from_str("0x07").expect("failed to parse hex"));
+        assert_eq!(vm.exitcode, 10, "STOP should succeed");
     }
 
     #[test]
@@ -1457,7 +1461,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // Should have pushed 0 onto the stack
-        assert_eq!(vm.stack.peek(0).value, U256::ZERO);
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::ZERO);
         assert_eq!(vm.exitcode, 10); // STOP exit code
     }
 
@@ -1478,7 +1482,7 @@ mod tests {
         let mut vm = new_test_vm_with_fork("0x600260011b00", HardFork::Constantinople);
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from(4));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from(4));
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1500,7 +1504,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // Should have loaded 0 from empty transient storage
-        assert_eq!(vm.stack.peek(0).value, U256::ZERO);
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::ZERO);
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1522,7 +1526,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // CLZ(1) = 255 (255 leading zeros in a 256-bit integer)
-        assert_eq!(vm.stack.peek(0).value, U256::from(255));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from(255));
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1534,7 +1538,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // CLZ(0) = 256 (special case per EIP-7939)
-        assert_eq!(vm.stack.peek(0).value, U256::from(256));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from(256));
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1551,7 +1555,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // CLZ(0x80...00) = 0 (no leading zeros)
-        assert_eq!(vm.stack.peek(0).value, U256::ZERO);
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::ZERO);
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1572,7 +1576,7 @@ mod tests {
         vm.execute().expect("execution failed!");
 
         // PUSH0 should work with default (Latest) hardfork
-        assert_eq!(vm.stack.peek(0).value, U256::ZERO);
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::ZERO);
         assert_eq!(vm.exitcode, 10);
     }
 
@@ -1583,6 +1587,6 @@ mod tests {
         let mut vm = new_test_vm_with_fork("0x6001600201", HardFork::Frontier);
         vm.execute().expect("execution failed!");
 
-        assert_eq!(vm.stack.peek(0).value, U256::from(3));
+        assert_eq!(vm.stack.peek(0).expect("peek").value, U256::from(3));
     }
 }

--- a/crates/vm/src/core/vm/handlers/arithmetic.rs
+++ b/crates/vm/src/core/vm/handlers/arithmetic.rs
@@ -111,9 +111,9 @@ pub fn exp(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
     let exponent = vm.stack.pop()?;
     let result = a.value.overflowing_pow(exponent.value).0;
 
-    // consume dynamic gas
-    let exponent_byte_size = exponent.value.bit_len() / 8;
-    let gas_cost = 50 * exponent_byte_size;
+    // Dynamic gas: 50 * ⌈exponent bit width in bytes⌉ (matches `ceil(log256(exp))` when exp > 0)
+    let exponent_byte_len = (exponent.value.bit_len() + 7) / 8;
+    let gas_cost = 50 * exponent_byte_len as u128;
     vm.consume_gas(gas_cost as u128);
 
     vm.push_with_optimization(result, &a, &exponent, operation);
@@ -122,15 +122,17 @@ pub fn exp(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// SIGNEXTEND - Extend length of two's complement signed integer
 pub fn signextend(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
-    let x = vm.stack.pop()?.value;
-    let b = vm.stack.pop()?.value;
+    let byte_idx = vm.stack.pop()?.value;
+    let word = vm.stack.pop()?.value;
 
-    let t = x * U256::from(8u32) + U256::from(7u32);
-    let sign_bit = U256::from(1u32) << t;
-
-    // (b & sign_bit - 1) - (b & sign_bit)
-    let result =
-        (b & (sign_bit.overflowing_sub(U256::from(1u32)).0)).overflowing_sub(b & sign_bit).0;
+    let result = if byte_idx > U256::from(31u8) {
+        // Yellow Paper / evm.codes: if k > 31, 𝑏 is unchanged
+        word
+    } else {
+        let t = byte_idx * U256::from(8u32) + U256::from(7u32);
+        let sign_bit = U256::from(1u32) << t;
+        (word & (sign_bit.overflowing_sub(U256::from(1u32)).0)).overflowing_sub(word & sign_bit).0
+    };
 
     vm.stack.push(result, operation);
     Ok(())

--- a/crates/vm/src/core/vm/handlers/control.rs
+++ b/crates/vm/src/core/vm/handlers/control.rs
@@ -35,14 +35,11 @@ pub fn jump(
     // Safely convert U256 to u128
     let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
-    // Check if JUMPDEST is valid and throw with 790 if not (invalid jump destination)
-    if (pc <=
-        vm.bytecode
-            .len()
-            .try_into()
-            .expect("impossible case: bytecode is larger than u128::MAX")) &&
-        (vm.bytecode[pc as usize] != opcodes::JUMPDEST)
-    {
+    let bytecode_len: u128 =
+        vm.bytecode.len().try_into().expect("impossible case: bytecode is larger than u128::MAX");
+
+    // Out-of-range or non-JUMPDEST is an invalid jump (790); avoid indexing past bytecode.
+    if pc >= bytecode_len || vm.bytecode[pc as usize] != opcodes::JUMPDEST {
         vm.exit(790, Vec::new());
         return Some(Instruction {
             instruction: last_instruction,
@@ -52,9 +49,8 @@ pub fn jump(
             input_operations: input_operations.to_vec(),
             output_operations: Vec::new(),
         });
-    } else {
-        vm.instruction = pc + 1;
     }
+    vm.instruction = pc + 1;
     None
 }
 
@@ -65,22 +61,18 @@ pub fn jumpi(
     inputs: &[U256],
     input_operations: &[WrappedOpcode],
 ) -> Option<Instruction> {
-    let pc = vm.stack.pop().ok()?.value;
+    // EVM JUMPI: stack top is condition `b`, below is jump counter `cnt` (see yellow paper / evm.codes).
     let condition = vm.stack.pop().ok()?.value;
+    let pc = vm.stack.pop().ok()?.value;
 
     // Safely convert U256 to u128
     let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
     if !condition.is_zero() {
-        // Check if JUMPDEST is valid and throw with 790 if not (invalid jump
-        // destination)
-        if (pc <
-            vm.bytecode
-                .len()
-                .try_into()
-                .expect("impossible case: bytecode is larger than u128::MAX")) &&
-            (vm.bytecode[pc as usize] != opcodes::JUMPDEST)
-        {
+        let bytecode_len: u128 =
+            vm.bytecode.len().try_into().expect("impossible case: bytecode is larger than u128::MAX");
+        // Invalid jump if out of range or not a JUMPDEST (mirror `jump`).
+        if pc >= bytecode_len || vm.bytecode[pc as usize] != opcodes::JUMPDEST {
             vm.exit(790, Vec::new());
             return Some(Instruction {
                 instruction: last_instruction,
@@ -90,9 +82,8 @@ pub fn jumpi(
                 input_operations: input_operations.to_vec(),
                 output_operations: Vec::new(),
             });
-        } else {
-            vm.instruction = pc + 1;
         }
+        vm.instruction = pc + 1;
     }
     None
 }

--- a/crates/vm/src/core/vm/handlers/environment.rs
+++ b/crates/vm/src/core/vm/handlers/environment.rs
@@ -81,19 +81,20 @@ pub fn calldatacopy(
     vm: &mut VM,
     #[cfg(feature = "experimental")] operation: WrappedOpcode,
 ) -> Result<()> {
-    let dest_offset = vm.stack.pop()?.value;
-    let offset = vm.stack.pop()?.value;
+    // Stack (top first): size, calldata offset, memory offset
     let size = vm.stack.pop()?.value;
+    let offset = vm.stack.pop()?.value;
+    let dest_offset = vm.stack.pop()?.value;
 
     let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
     let offset: usize = offset.try_into().unwrap_or(usize::MAX);
-    let size: usize = size.try_into().unwrap_or(vm.calldata.len()).min(vm.calldata.len());
+    let size: usize = size.try_into().unwrap_or(usize::MAX);
 
     let value = VM::safe_copy_data(&vm.calldata, offset, size);
 
-    // consume dynamic gas
+    // consume dynamic gas (memory expansion uses the destination range)
     let minimum_word_size = size.div_ceil(32) as u128;
-    let gas_cost = 3 * minimum_word_size + vm.memory.expansion_cost(offset, size);
+    let gas_cost = 3 * minimum_word_size + vm.memory.expansion_cost(dest_offset, size);
     vm.consume_gas(gas_cost);
 
     vm.memory.store_with_opcode(
@@ -118,19 +119,18 @@ pub fn codecopy(
     vm: &mut VM,
     #[cfg(feature = "experimental")] operation: WrappedOpcode,
 ) -> Result<()> {
-    let dest_offset = vm.stack.pop()?.value;
-    let offset = vm.stack.pop()?.value;
     let size = vm.stack.pop()?.value;
+    let offset = vm.stack.pop()?.value;
+    let dest_offset = vm.stack.pop()?.value;
 
     let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
     let offset: usize = offset.try_into().unwrap_or(usize::MAX);
-    let size: usize = size.try_into().unwrap_or(vm.bytecode.len()).min(vm.bytecode.len());
+    let size: usize = size.try_into().unwrap_or(usize::MAX);
 
     let value = VM::safe_copy_data(&vm.bytecode, offset, size);
 
-    // consume dynamic gas
     let minimum_word_size = size.div_ceil(32) as u128;
-    let gas_cost = 3 * minimum_word_size + vm.memory.expansion_cost(offset, size);
+    let gas_cost = 3 * minimum_word_size + vm.memory.expansion_cost(dest_offset, size);
     vm.consume_gas(gas_cost);
 
     vm.memory.store_with_opcode(
@@ -170,12 +170,12 @@ pub fn extcodecopy(
     vm: &mut VM,
     #[cfg(feature = "experimental")] operation: WrappedOpcode,
 ) -> Result<()> {
-    let address = vm.stack.pop()?.value;
-    let dest_offset = vm.stack.pop()?.value;
-    vm.stack.pop()?;
+    // Stack (top first): size, code offset, memory offset, address
     let size = vm.stack.pop()?.value;
+    let _code_offset = vm.stack.pop()?.value;
+    let dest_offset = vm.stack.pop()?.value;
+    let address = vm.stack.pop()?.value;
 
-    // Safely convert U256 to usize
     let dest_offset: usize = dest_offset.try_into().unwrap_or(0);
     let mut size: usize = size.try_into().unwrap_or(256);
     size = size.max(256);
@@ -215,13 +215,13 @@ pub fn returndatacopy(
     vm: &mut VM,
     #[cfg(feature = "experimental")] operation: WrappedOpcode,
 ) -> Result<()> {
-    let dest_offset = vm.stack.pop()?.value;
-    vm.stack.pop()?;
     let size = vm.stack.pop()?.value;
+    let ret_data_offset = vm.stack.pop()?.value;
+    let dest_offset = vm.stack.pop()?.value;
 
-    // Safely convert U256 to usize
     let dest_offset: usize = dest_offset.try_into().unwrap_or(0);
     let size: usize = size.try_into().unwrap_or(256);
+    let _ret_data_offset = ret_data_offset;
 
     let mut value = Vec::with_capacity(size);
     value.fill(0xff);

--- a/crates/vm/src/core/vm/handlers/memory.rs
+++ b/crates/vm/src/core/vm/handlers/memory.rs
@@ -76,22 +76,23 @@ pub fn msize(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
     Ok(())
 }
 
-/// MCOPY - Copy memory areas
+/// MCOPY - Copy memory areas (EIP-5656; stack top: length, source offset, dest offset)
 pub fn mcopy(vm: &mut VM, #[cfg(feature = "experimental")] operation: WrappedOpcode) -> Result<()> {
+    let size_word = vm.stack.pop()?.value;
+    let src_offset = vm.stack.pop()?.value;
     let dest_offset = vm.stack.pop()?.value;
-    let offset = vm.stack.pop()?.value;
-    let size = vm.stack.pop()?.value;
 
-    let dest_offset: usize = dest_offset.try_into().unwrap_or(u128::MAX as usize);
-    let offset: usize = offset.try_into().unwrap_or(u128::MAX as usize);
-    let memory_size: usize = vm.memory.size().try_into().expect("failed to convert u128 to usize");
-    let size: usize = size.try_into().unwrap_or(memory_size).min(memory_size);
+    let dest_offset: usize = dest_offset.try_into().unwrap_or(usize::MAX);
+    let offset: usize = src_offset.try_into().unwrap_or(usize::MAX);
+    let size: usize = size_word.try_into().unwrap_or(usize::MAX);
 
     let value = VM::safe_copy_data(&vm.memory.memory, offset, size);
 
-    // consume dynamic gas
+    // consume dynamic gas — memory expansion covers source and destination ranges (EIP-5656)
     let minimum_word_size = size.div_ceil(32) as u128;
-    let gas_cost = 3 * minimum_word_size + vm.memory.expansion_cost(offset, size);
+    let expand_src = vm.memory.expansion_cost(offset, size);
+    let expand_dest = vm.memory.expansion_cost(dest_offset, size);
+    let gas_cost = 3 * minimum_word_size + expand_src.max(expand_dest);
     vm.consume_gas(gas_cost);
 
     vm.memory.store_with_opcode(

--- a/crates/vm/src/core/vm/handlers/system.rs
+++ b/crates/vm/src/core/vm/handlers/system.rs
@@ -17,8 +17,14 @@ pub fn create(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// CALL - Message-call into an account
 pub fn call(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
+    // Stack (top first): retSize, retOffset, argsSize, argsOffset, value, address, gas
+    let _ret_size = vm.stack.pop()?.value;
+    let _ret_offset = vm.stack.pop()?.value;
+    let _args_size = vm.stack.pop()?.value;
+    let _args_offset = vm.stack.pop()?.value;
+    let _value = vm.stack.pop()?.value;
     let address = vm.stack.pop()?.value;
-    vm.stack.pop_n(6)?;
+    let _gas = vm.stack.pop()?.value;
 
     // consume dynamic gas
     if !vm.address_access_set.contains(&address) {
@@ -34,8 +40,13 @@ pub fn call(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// CALLCODE - Message-call into this account with alternative account's code
 pub fn callcode(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
+    let _ret_size = vm.stack.pop()?.value;
+    let _ret_offset = vm.stack.pop()?.value;
+    let _args_size = vm.stack.pop()?.value;
+    let _args_offset = vm.stack.pop()?.value;
+    let _value = vm.stack.pop()?.value;
     let address = vm.stack.pop()?.value;
-    vm.stack.pop_n(6)?;
+    let _gas = vm.stack.pop()?.value;
 
     // consume dynamic gas
     if !vm.address_access_set.contains(&address) {
@@ -51,8 +62,9 @@ pub fn callcode(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// RETURN - Halt execution returning output data
 pub fn op_return(vm: &mut VM) -> Result<()> {
-    let offset = vm.stack.pop()?.value;
+    // EVM: top of stack is `size`, then `offset`
     let size = vm.stack.pop()?.value;
+    let offset = vm.stack.pop()?.value;
 
     // Safely convert U256 to usize
     let offset: usize = offset.try_into().unwrap_or(usize::MAX);
@@ -68,8 +80,13 @@ pub fn op_return(vm: &mut VM) -> Result<()> {
 
 /// DELEGATECALL - Message-call into this account with an alternative account's code
 pub fn delegatecall(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
+    // Stack (top first): retSize, retOffset, argsSize, argsOffset, address, gas
+    let _ret_size = vm.stack.pop()?.value;
+    let _ret_offset = vm.stack.pop()?.value;
+    let _args_size = vm.stack.pop()?.value;
+    let _args_offset = vm.stack.pop()?.value;
     let address = vm.stack.pop()?.value;
-    vm.stack.pop_n(5)?;
+    let _gas = vm.stack.pop()?.value;
 
     // consume dynamic gas
     if !vm.address_access_set.contains(&address) {
@@ -85,8 +102,12 @@ pub fn delegatecall(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// STATICCALL - Static message-call into an account
 pub fn staticcall(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
+    let _ret_size = vm.stack.pop()?.value;
+    let _ret_offset = vm.stack.pop()?.value;
+    let _args_size = vm.stack.pop()?.value;
+    let _args_offset = vm.stack.pop()?.value;
     let address = vm.stack.pop()?.value;
-    vm.stack.pop_n(5)?;
+    let _gas = vm.stack.pop()?.value;
 
     // consume dynamic gas
     if !vm.address_access_set.contains(&address) {
@@ -109,8 +130,8 @@ pub fn create2(vm: &mut VM, operation: WrappedOpcode) -> Result<()> {
 
 /// REVERT - Halt execution reverting state changes
 pub fn revert(vm: &mut VM) -> Result<()> {
-    let offset = vm.stack.pop()?.value;
     let size = vm.stack.pop()?.value;
+    let offset = vm.stack.pop()?.value;
 
     // Safely convert U256 to usize
     let offset: usize = offset.try_into().unwrap_or(usize::MAX);

--- a/crates/vm/src/ext/exec/mod.rs
+++ b/crates/vm/src/ext/exec/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     },
 };
 use eyre::Result;
+use alloy::primitives::U256;
 use hashbrown::HashMap;
 use heimdall_common::utils::strings::decode_hex;
 use std::time::Instant;
@@ -170,14 +171,14 @@ impl VM {
                 );
 
                 let jump_condition: Option<String> =
-                    last_instruction.input_operations.get(1).map(|op| op.solidify());
+                    last_instruction.input_operations.get(0).map(|op| op.solidify());
                 let jump_taken =
-                    last_instruction.inputs.get(1).map(|op| !op.is_zero()).unwrap_or(true);
+                    last_instruction.inputs.get(0).is_some_and(|word| !word.is_zero());
 
-                // build hashable jump frame
+                // build hashable jump frame (`inputs`: [condition, jump counter] === stack top-first)
                 let jump_frame = JumpFrame::new(
                     last_instruction.instruction,
-                    last_instruction.inputs[0],
+                    *last_instruction.inputs.get(1).unwrap_or(&U256::ZERO),
                     vm.stack.size(),
                     jump_taken,
                 );
@@ -321,24 +322,21 @@ impl VM {
                     }
                 }
 
-                if last_instruction.opcode == 0x56 {
-                    continue;
-                }
-
                 // we didnt break out, so now we crate branching paths to cover all possibilities
                 *branch_count += 1;
+                let jump_counter = last_instruction.inputs.get(1).copied().unwrap_or(U256::ZERO);
                 trace!(
-                    "creating branching paths at instructions {} (JUMPDEST) and {} (CONTINUE)",
-                    last_instruction.inputs[0],
+                    "creating branching paths at jump target +1 from {} and fall-through from {}",
+                    jump_counter,
                     last_instruction.instruction + 1
                 );
 
                 // we need to create a trace for the path that wasn't taken.
                 if !jump_taken {
-                    // push a new vm trace to the children
+                    // Current VM continued past JUMPI (not taken). Spawn an alternate at the jump destination.
                     let mut trace_vm = vm.clone();
-                    trace_vm.instruction =
-                        last_instruction.inputs[0].try_into().unwrap_or(u128::MAX) + 1;
+                    let jump_dest: u128 = jump_counter.try_into().unwrap_or(u128::MAX);
+                    trace_vm.instruction = jump_dest.saturating_add(1);
                     match trace_vm.recursive_map(branch_count, handled_jumps, timeout_at) {
                         Ok(Some(child_trace)) => vm_trace.children.push(child_trace),
                         Ok(None) => {}
@@ -359,9 +357,9 @@ impl VM {
                     }
                     break;
                 } else {
-                    // push a new vm trace to the children
+                    // Jump was taken: explore fall-through sibling.
                     let mut trace_vm = vm.clone();
-                    trace_vm.instruction = last_instruction.instruction + 1;
+                    trace_vm.instruction = last_instruction.instruction.saturating_add(1);
                     match trace_vm.recursive_map(branch_count, handled_jumps, timeout_at) {
                         Ok(Some(child_trace)) => vm_trace.children.push(child_trace),
                         Ok(None) => {}


### PR DESCRIPTION
- JUMPI pops condition then counter; JUMP/JUMPI reject out-of-range targets without slicing past bytecode.

- Restore correct stack order for CALL family, RETURN/REVERT, and memory copy opcodes (incl. gas on destination expansion where applicable).

- SIGNEXTEND skips work when byte index > 31; EXP gas uses ceil(bit_len / 8) for nonzero exponents.

- MCOPY uses EIP-5656 stack order and max(source, dest) expansion for dynamic gas.

- Stack peek/peek_no longer fabricates values; insufficient depth surfaces as stack underflow in step.

- Symbolic executor uses JUMPI inputs[0]/[1] for condition vs jump target and swaps branch exploration PCs.

- Decode rejects calldata shorter than four bytes and replaces panics with errors on raw heuristic failure.

- Cache rejects path-like keys; safe hex decode and portable delete via std::fs; docs clarify expiry is absolute unix ts.

- Use std::fs for delete_path in heimdall-common on Windows-compatible removal.

BREAKING CHANGE: Stack::peek returns Option<StackFrame>; Stack::peek_n returns Option<Vec<_>>.

Tests: update jump/JUMPI bytecode and assertions for corrected control flow.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## What changed? Why?

<!--
Please provide a summary of the changes and the related issue.
If it fixes a bug or resolves a feature request, be sure to link to that issue.
If you have relevant screenshots, please add them here.
-->

## Notes to reviewers

<!--
Please list the key files changed or added as part of this PR.
-->

## How has it been tested?

<!--
Please describe the tests that you ran to verify your changes.
Include screenshots if appropriate.
-->
