### PR TITLE
fix: pin docker builder to bookworm to resolve glibc mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-slim AS builder
+FROM rust:1.91-slim-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## What changed? Why?

pins the docker builder stage from `rust:1.91-slim` (debian trixie, glibc 2.39) to `rust:1.91-slim-bookworm` so it matches the `debian:bookworm-slim` runtime stage (glibc 2.36).

without this, the binary is compiled against a newer glibc than what's available in the runtime image, causing `GLIBC_2.38` / `GLIBC_2.39 not found` errors on container startup.

closes #693

## Notes to reviewers

- `Dockerfile` — one-line change to pin the builder base image to bookworm

## How has it been tested?

- built the image locally with `docker build --platform linux/amd64` and verified `heimdall --help` runs without glibc errors
`