### PR TITLE
fix: remove doc comments on clap args structs that leaked into stdout

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -63,7 +63,6 @@ pub(crate) enum Subcommands {
     Inspect(InspectArgs),
 }
 
-/// The log configuration.
 #[derive(Debug, Args)]
 #[clap(next_help_heading = "LOGGING")]
 pub(crate) struct LogArgs {
@@ -164,7 +163,6 @@ impl FromStr for ColorMode {
     }
 }
 
-/// The verbosity settings for the cli.
 #[derive(Debug, Copy, Clone, Args)]
 #[clap(next_help_heading = "DISPLAY")]
 pub(crate) struct Verbosity {


### PR DESCRIPTION
## What changed? Why?

removes doc comments (`///`) from `LogArgs` and `Verbosity` structs in `crates/cli/src/args.rs`. clap interprets doc comments on `Args`-deriving structs as display text, which caused "The log configuration" to be printed as a stray line on startup.

closes #695

## Notes to reviewers

- `crates/cli/src/args.rs` - removed two doc comments that clap was rendering as output

## How has it been tested?

- `make check` passes
- verified `heimdall --help` no longer prints the stray "The log configuration" line
