### PR TITLE
ci: move bench workflow off sunset buildjet runner

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   runBenchmark:
     name: run benchmark
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: boa-dev/criterion-compare-action@v3


### PR DESCRIPTION
## What changed? Why?

Buildjet has been sunset and can no longer schedule its `buildjet-16vcpu-ubuntu-2204` runner. This PR migrates the bench workflow to GitHub's standard `ubuntu-latest` hosted runner to keep CI unblocked.

Changed: `.github/workflows/bench.yml` — replaced `runs-on: buildjet-16vcpu-ubuntu-2204` with `runs-on: ubuntu-latest`

## Notes to reviewers

- Only one line changed in `.github/workflows/bench.yml`
- All other workflow logic is preserved: still triggers on `pull_request`, maintains the same concurrency group with `cancel-in-progress`, uses `boa-dev/criterion-compare-action@v3`, and keeps the old-benchmark-comment cleanup script
- `ubuntu-latest` is a 4vCPU runner (vs the original 16vCPU buildjet box). If higher core count is needed, we can upgrade to a GitHub larger runner (e.g. `ubuntu-latest-16-cores`), but that requires provisioning in repo/org settings

## How has it been tested?

- Verified the workflow syntax is valid
- The action configuration and all steps remain unchanged and will work with the new runner