### PR TITLE
fix(vm): resolve function selectors with leading zero bytes

### DIFF
--- a/crates/core/tests/test_decompile.rs
+++ b/crates/core/tests/test_decompile.rs
@@ -385,6 +385,51 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn test_decompile_leading_zero_byte_selector() {
+        // Regression test for function selectors with a leading zero byte (e.g. `0x00aabbcc`).
+        //
+        // Observed while decompiling an unverified Polygon (Polymarket-adjacent) contract: any
+        // externally-dispatched function whose 4-byte selector begins with `0x00` was silently
+        // dropped from the decompilation, because the dispatcher's `PUSH4` constant is solidified
+        // without its leading zero byte (`0xaabbcc`) while the selector matcher compared against
+        // the un-reduced `00aabbcc`, so the entry point never resolved.
+        //
+        // This minimal dispatcher routes two selectors: `0x00aabbcc` (leading zero byte, previously
+        // dropped) and `0x11223344` (control). Both must be recovered.
+        let bytecode = "60003560e01c806300aabbcc14610020578063112233441461002b57600080fd5b604260005260206000f35b604360005260206000f3";
+
+        let result = decompile(DecompilerArgs {
+            target: bytecode.to_string(),
+            rpc_url: String::from(""),
+            default: true,
+            skip_resolving: true,
+            include_solidity: true,
+            include_yul: false,
+            output: String::from(""),
+            name: String::from(""),
+            timeout: 10000,
+            abi: None,
+            openrouter_api_key: String::from(""),
+            model: String::from(""),
+            llm_postprocess: false,
+            etherscan_api_key: String::from(""),
+            hardfork: HardFork::Latest,
+        })
+        .await
+        .expect("failed to decompile");
+
+        let source = result.source.as_ref().expect("decompile source is empty");
+        assert!(
+            source.contains("unresolved_00aabbcc"),
+            "leading zero-byte selector `0x00aabbcc` was dropped from the decompilation"
+        );
+        assert!(
+            source.contains("unresolved_11223344"),
+            "control selector `0x11223344` should still be recovered"
+        );
+    }
+
+    #[tokio::test]
     #[ignore]
     async fn heavy_integration_test() {
         let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vm/src/ext/selectors.rs
+++ b/crates/vm/src/ext/selectors.rs
@@ -4,10 +4,11 @@ use std::{
     time::Instant,
 };
 
+use alloy::primitives::U256;
 use eyre::Result;
 use heimdall_common::{
     ether::signatures::{ResolveSelector, ResolvedFunction},
-    utils::strings::decode_hex,
+    utils::strings::{decode_hex, encode_hex_reduced},
 };
 use tokio::task;
 use tracing::{debug, error, info, trace, warn};
@@ -113,7 +114,14 @@ pub fn resolve_entry_point(vm: &mut VM, selector: &str) -> u128 {
     let mut handled_jumps = HashSet::new();
 
     // execute the EVM call to find the entry point for the given selector
-    vm.calldata = decode_hex(selector).expect("Failed to decode selector.");
+    let selector_bytes = decode_hex(selector).expect("Failed to decode selector.");
+    vm.calldata = selector_bytes.clone();
+
+    // selectors with leading zero-bytes (e.g. `0x00aabbcc`) are solidified without those
+    // bytes in the jump condition (e.g. `0xaabbcc`), so match against the same reduced form
+    // that `solidify` produces. otherwise these functions are dropped from the dispatcher.
+    let reduced_selector = encode_hex_reduced(U256::from_be_slice(&selector_bytes));
+
     while vm.bytecode.len() >= vm.instruction as usize {
         let call = match vm.step() {
             Ok(call) => call,
@@ -125,7 +133,7 @@ pub fn resolve_entry_point(vm: &mut VM, selector: &str) -> u128 {
             let jump_condition = call.last_instruction.input_operations[1].solidify();
             let jump_taken = call.last_instruction.inputs[1].try_into().unwrap_or(1);
 
-            if jump_condition.contains(selector) &&
+            if jump_condition.contains(&reduced_selector) &&
                 jump_condition.contains("msg.data[0]") &&
                 jump_condition.contains(" == ") &&
                 jump_taken == 1


### PR DESCRIPTION
## What changed? Why?

**Observed failure.** While decompiling an unverified Polygon contract (a
participant-linked, bot-like contract adjacent to Polymarket, selected from
PolygonScan; heimdall-cli v0.9.2 on ARM64), any externally-dispatched function
whose 4-byte selector begins with a zero byte (e.g. `0x00aabbcc`) was silently
dropped from the output. Those selectors never appeared in the recovered ABI or
Solidity, so the contract's routing/dispatch logic was incomplete and could not
be trusted.

**Root cause.** In `resolve_entry_point` (`crates/vm/src/ext/selectors.rs`), the
dispatcher's `PUSH4` constant is solidified through `encode_hex_reduced`, which
strips leading zero bytes (`0x00aabbcc` → `0xaabbcc`). The matcher, however,
compared `jump_condition.contains(selector)` against the un-reduced selector
string (`00aabbcc`). The substring never matched, the entry point resolved to
`0`, and `find_function_selectors` skipped the selector entirely. Only selectors
without a leading zero byte were affected — which is why the bug was intermittent
and easy to miss.

**Fix.** Compare against the same reduced form the solidifier emits
(`encode_hex_reduced(U256::from_be_slice(&selector_bytes))`). Selectors with a
leading zero byte now resolve; all other selectors are byte-for-byte unaffected.

## Notes to reviewers

- `crates/vm/src/ext/selectors.rs` — `resolve_entry_point`: match the reduced
  selector form; added `encode_hex_reduced` / `U256` imports.
- `crates/core/tests/test_decompile.rs` — regression test.

## How has it been tested?

- Added `test_decompile_leading_zero_byte_selector`: a minimal synthetic
  dispatcher routing `0x00aabbcc` (leading zero byte, previously dropped) and
  `0x11223344` (control). It fails before the fix (only `11223344` recovered) and
  passes after (both recovered). Verified the same before/after behavior directly
  via the CLI on the fixture bytecode.
- `cargo test -p heimdall-vm`: 153 + 34 tests pass.
- Bytecode-based decompile integration tests pass; `cargo +nightly fmt --check`
  and `cargo clippy -p heimdall-vm` are clean. RPC/address-based tests were not
  run (no `RPC_URL` in this environment).

## Limitations

- The regression uses a minimal synthetic fixture that reproduces the exact
  failing dispatcher pattern (leading-zero-byte selector); the original
  unverified contract is not committed, and no PolygonScan/RPC dependency is
  added. This change only restores discovery of these selectors — it does not
  claim to recover the contract's higher-level business logic.