### PR TITLE
fix(bifrost): detect package manager for non-Debian Linux hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once you have installed `bifrost`, you can use it to install Heimdall using the 
 bifrost
 ```
 
-After compilation, the `heimdall` command will be available to use from a new terminal. For advanced options, see the [bifrost documentation](https://jbecker.dev/r/heimdall-rs/wiki/installation).
+After compilation, the `heimdall` command will be available to use from a new terminal. `bifrost` supports both x86_64 and ARM64 Linux (Debian/Ubuntu, Amazon Linux, Fedora/RHEL, Arch, openSUSE, and Alpine) as well as macOS; see [supported platforms](./bifrost/README.md#supported-platforms) for details. For advanced options, see the [bifrost documentation](https://jbecker.dev/r/heimdall-rs/wiki/installation).
 
 _Having trouble? Check out the [Troubleshooting](https://jbecker.dev/r/heimdall-rs/wiki/troubleshooting) section in the wiki._
 

--- a/bifrost/README.md
+++ b/bifrost/README.md
@@ -9,6 +9,31 @@ Bifrost is heimdall's installer and version manager. Named after the rainbow bri
 curl -L http://get.heimdall.rs | bash
 ```
 
+## Supported platforms
+
+`bifrost` builds heimdall from source by default, which requires a C toolchain
+and the OpenSSL development headers. When installing on Linux, bifrost detects
+the host package manager and installs those dependencies with it:
+
+| Package manager | Distributions (examples)                | Packages installed                     |
+| --------------- | --------------------------------------- | -------------------------------------- |
+| `apt-get`       | Debian, Ubuntu                          | `libssl-dev`, `build-essential`        |
+| `dnf` / `yum`   | Amazon Linux 2023/2, Fedora, RHEL, CentOS | `openssl-devel`, `gcc`, `gcc-c++`, `make` |
+| `pacman`        | Arch                                    | `openssl`, `base-devel`                |
+| `zypper`        | openSUSE                                | `libopenssl-devel`, `gcc`, `gcc-c++`, `make` |
+| `apk`           | Alpine                                  | `openssl-dev`, `build-base`            |
+
+Both `x86_64`/`amd64` and `aarch64`/`arm64` hosts are supported. For example, an
+ARM64 Amazon Linux 2023 host uses `dnf` for its build dependencies and compiles
+a native `aarch64` binary — no Debian/`apt-get` assumptions and no manual
+package-path workarounds are required. Pre-compiled binaries (`--binary`) are
+published for `linux-amd64`, `linux-arm64`, `macos-amd64`, and `macos-arm64`.
+
+On macOS and other non-Linux systems bifrost assumes the toolchain and OpenSSL
+are provided by the system (or, on macOS, homebrew) and does not install system
+packages. If bifrost cannot detect a supported package manager it prints the
+dependencies to install manually instead of guessing at one.
+
 ## Usage
 
 To install the latest stable release:

--- a/bifrost/bifrost
+++ b/bifrost/bifrost
@@ -11,8 +11,7 @@ main() {
     requires_cmd git
     requires_cmd curl
     requires_cmd cargo
-    ensure_apt_package "libssl-dev"
-    ensure_apt_package "build-essential"
+    ensure_build_dependencies
 
     # parsing parameters
     while [[ $1 ]]; do
@@ -208,20 +207,70 @@ ensure() {
     if ! "$@"; then echo "bifrost: required command '$*' failed."; exit 1; fi
 }
 
-# ensure an apt package is installed
-ensure_apt_package() {
-    # if we are not on a linux system, return success
+# detect the system package manager, preferring apt-get so existing
+# Debian/Ubuntu behavior is preserved. echoes an empty string if none is known.
+detect_package_manager() {
+    local pm
+    for pm in apt-get dnf yum pacman zypper apk; do
+        if command_exists "$pm"; then
+            echo "$pm"
+            return
+        fi
+    done
+}
+
+# echo the OpenSSL development headers and C toolchain packages required to
+# build heimdall from source for the given package manager. an empty result
+# means the package manager is not supported.
+build_dependency_packages() {
+    case $1 in
+        apt-get) echo "libssl-dev build-essential" ;;
+        dnf|yum) echo "openssl-devel gcc gcc-c++ make" ;;
+        pacman)  echo "openssl base-devel" ;;
+        zypper)  echo "libopenssl-devel gcc gcc-c++ make" ;;
+        apk)     echo "openssl-dev build-base" ;;
+    esac
+}
+
+# echo the full, non-interactive install command for the given package manager
+# and packages. an empty result means bifrost cannot install automatically and
+# must not guess at a package manager.
+package_install_command() {
+    local pm=$1; shift
+    case $pm in
+        apt-get) echo "sudo apt-get install -y $*" ;;
+        dnf)     echo "sudo dnf install -y $*" ;;
+        yum)     echo "sudo yum install -y $*" ;;
+        pacman)  echo "sudo pacman -S --needed --noconfirm $*" ;;
+        zypper)  echo "sudo zypper install -y $*" ;;
+        apk)     echo "sudo apk add $*" ;;
+    esac
+}
+
+# ensure the OpenSSL headers and C toolchain needed to build from source are
+# installed, using whichever package manager the host provides.
+ensure_build_dependencies() {
+    # macOS and other systems ship a toolchain / provide OpenSSL via their own
+    # channels (e.g. homebrew), so we don't touch system packages there.
     if [[ "$OSTYPE" != "linux-gnu"* ]]; then
         return
     fi
 
-    # if the package is not installed, install it
-    if ! dpkg -l | grep -q $1; then
-        echo "bifrost: installing $1."
-        ensure sudo apt-get install -y $1
-    else
-        echo "bifrost: $1 is already installed."
+    local pm packages cmd
+    pm=$(detect_package_manager)
+    packages=$(build_dependency_packages "$pm")
+    cmd=$(package_install_command "$pm" $packages)
+
+    # no known package manager: fail loudly with actionable guidance rather than
+    # invoking the wrong one (e.g. apt-get on Amazon Linux / Fedora / Arch).
+    if [ -z "$cmd" ]; then
+        echo "bifrost: could not detect a supported package manager (apt-get, dnf, yum, pacman, zypper, apk)."
+        echo "bifrost: please install an OpenSSL development package and a C toolchain, then re-run bifrost."
+        return
     fi
+
+    echo "bifrost: ensuring build dependencies ($packages) via $pm."
+    ensure $cmd
 }
 
 # command_exists checks if a command exists
@@ -244,5 +293,7 @@ set_version() {
     sed -i "" "s/^version.*/version = \"${version}\"/" $file
 }
 
-# run main
-main "$@" || exit 1
+# run main (skipped when the script is sourced, e.g. by the test suite)
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@" || exit 1
+fi

--- a/bifrost/tests/bifrost-tests
+++ b/bifrost/tests/bifrost-tests
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Regression tests for bifrost's platform / package-manager detection.
+#
+# These tests source `bifrost` and exercise its pure decision functions in
+# isolation. They mock the presence of package managers by placing fake
+# executables on a controlled PATH, so they do NOT require apt-get, root
+# privileges, a live network, or any particular host distribution.
+#
+# Run with: bash bifrost/tests/bifrost-tests
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIFROST="$TESTS_DIR/../bifrost"
+
+# shellcheck source=/dev/null
+source "$BIFROST"
+set +e  # bifrost enables `set -e`; disable it so a failing assertion is reported
+
+FAILURES=0
+
+assert_eq() {
+    local expected=$1 actual=$2 name=$3
+    if [ "$expected" = "$actual" ]; then
+        echo "ok   - $name"
+    else
+        echo "FAIL - $name"
+        echo "         expected: '$expected'"
+        echo "         actual:   '$actual'"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_not_contains() {
+    local haystack=$1 needle=$2 name=$3
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "ok   - $name"
+    else
+        echo "FAIL - $name (found '$needle' in '$haystack')"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# build a PATH containing only fake executables for the given package managers
+mock_path() {
+    local dir
+    dir=$(mktemp -d)
+    for pm in "$@"; do
+        printf '#!/bin/sh\n' > "$dir/$pm"
+        chmod +x "$dir/$pm"
+    done
+    echo "$dir"
+}
+
+# --- detect_package_manager -------------------------------------------------
+
+# Debian/Ubuntu: apt-get is preferred even when other managers coexist.
+d=$(mock_path apt-get dnf yum)
+assert_eq "apt-get" "$(PATH="$d" detect_package_manager)" \
+    "detect prefers apt-get (Debian/Ubuntu behavior preserved)"
+
+# Amazon Linux 2023 / Fedora / RHEL: dnf is detected, no apt-get present.
+d=$(mock_path dnf yum)
+assert_eq "dnf" "$(PATH="$d" detect_package_manager)" \
+    "detect returns dnf on Amazon Linux 2023 / Fedora (the reproduction)"
+
+# Older RHEL/CentOS/Amazon Linux 2: only yum available.
+d=$(mock_path yum)
+assert_eq "yum" "$(PATH="$d" detect_package_manager)" \
+    "detect returns yum when only yum is available"
+
+# Arch / Alpine / SUSE.
+d=$(mock_path pacman); assert_eq "pacman" "$(PATH="$d" detect_package_manager)" "detect returns pacman (Arch)"
+d=$(mock_path apk);    assert_eq "apk"    "$(PATH="$d" detect_package_manager)" "detect returns apk (Alpine)"
+d=$(mock_path zypper); assert_eq "zypper" "$(PATH="$d" detect_package_manager)" "detect returns zypper (openSUSE)"
+
+# Unknown environment: no supported package manager.
+d=$(mock_path)
+assert_eq "" "$(PATH="$d" detect_package_manager)" \
+    "detect returns empty when no supported package manager exists"
+
+# --- build_dependency_packages ----------------------------------------------
+
+assert_eq "libssl-dev build-essential" "$(build_dependency_packages apt-get)" \
+    "apt-get maps to Debian dev packages (unchanged)"
+assert_eq "openssl-devel gcc gcc-c++ make" "$(build_dependency_packages dnf)" \
+    "dnf maps to openssl-devel + gcc toolchain"
+assert_eq "openssl-devel gcc gcc-c++ make" "$(build_dependency_packages yum)" \
+    "yum maps to openssl-devel + gcc toolchain"
+assert_eq "openssl base-devel" "$(build_dependency_packages pacman)" \
+    "pacman maps to openssl + base-devel"
+assert_eq "" "$(build_dependency_packages does-not-exist)" \
+    "unknown package manager maps to no packages"
+
+# --- package_install_command ------------------------------------------------
+
+assert_eq "sudo apt-get install -y libssl-dev build-essential" \
+    "$(package_install_command apt-get libssl-dev build-essential)" \
+    "apt-get install command is unchanged (Debian/Ubuntu preserved)"
+
+# End-to-end decision for the Amazon Linux 2023 / aarch64 reproduction: the
+# resolved command must use dnf and must NOT invoke apt-get.
+amzn_cmd="$(package_install_command dnf "$(build_dependency_packages dnf)")"
+assert_eq "sudo dnf install -y openssl-devel gcc gcc-c++ make" "$amzn_cmd" \
+    "Amazon Linux 2023 resolves to a dnf install command"
+assert_not_contains "$amzn_cmd" "apt-get" \
+    "Amazon Linux 2023 never falls back to apt-get"
+
+# Unsupported host: no command is produced, so bifrost errors out instead of
+# silently running the wrong package manager.
+assert_eq "" "$(package_install_command "")" \
+    "unsupported host yields no install command (no wrong package manager)"
+
+# ---------------------------------------------------------------------------
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All bifrost detection tests passed."
+    exit 0
+else
+    echo "$FAILURES test(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## What changed? Why?

**Reproduction:** On an ARM64/aarch64 Linux host running Amazon Linux 2023, the bundled `bifrost` installer aborted before heimdall could build. Its `ensure_apt_package` helper ran on every Linux host and probed packages with `dpkg -l`, then installed build dependencies with `sudo apt-get install -y`. Amazon Linux 2023 ships `dnf`/`yum` and has neither `dpkg` nor `apt-get`, so the step failed and forced a manual binary-path workaround before the native aarch64 binary (heimdall-cli v0.9.2) could be compiled.

**Root cause:** The installer's supported-platform contract silently assumed Debian/Ubuntu for all of Linux. Package existence checks (`dpkg`) and installation (`apt-get`) were hard-coded, and the Debian-only package names (`libssl-dev`, `build-essential`) had no equivalent mapping for other distributions.

**Fix:** `bifrost` now detects the host package manager — `apt-get`, `dnf`, `yum`, `pacman`, `zypper`, or `apk` — preferring `apt-get` so existing Debian/Ubuntu behavior is unchanged. It maps the required OpenSSL development headers and C toolchain to the correct package names per manager and runs that manager's non-interactive install command. If no supported package manager is detected, it prints the dependencies to install manually rather than silently invoking the wrong one. Architecture selection (x86_64/amd64 and aarch64/arm64) for the pre-compiled `--binary` path was already correct and is unchanged; the release workflow already publishes a `linux-arm64` artifact.

**Remaining platform limitations:** Distribution support is limited to hosts providing one of the six package managers above; anything else falls back to a manual-install message (no automated dependency installation). Live end-to-end installation was verified only for the Amazon Linux 2023 aarch64 reproduction and the preserved Debian `apt-get` decision — the other package managers are covered by decision-level tests, not live installs on each distro. macOS/other non-Linux hosts continue to assume the toolchain and OpenSSL are provided by the system (or homebrew).

## Notes to reviewers

Key changes:
- `bifrost/bifrost` — replaced `ensure_apt_package` with `detect_package_manager`, `build_dependency_packages`, `package_install_command`, and `ensure_build_dependencies`; added a `BASH_SOURCE` guard so the script can be sourced by tests without running `main`.
- `bifrost/tests/bifrost-tests` — new regression suite (no `.sh` extension, since the repo `.gitignore` excludes `*.sh`).
- `bifrost/README.md` — new "Supported platforms" section; `README.md` — brief platform-support note.

## How has it been tested?

- `bash bifrost/tests/bifrost-tests` — 16 assertions, all passing. Tests mock package managers via fake executables on a controlled `PATH`, so they require **no** `apt-get`, root, network, or particular host distribution. Coverage includes: apt-get preferred when multiple managers coexist (Debian preserved); `dnf` detected on the Amazon Linux 2023 reproduction with the resolved command asserted to never contain `apt-get`; `yum`/`pacman`/`zypper`/`apk` detection; unsupported-host yields no command; and the exact Debian package list/install command are unchanged.
- `bash -n` syntax check passes on the installer and test script.
- This change is shell-only and touches no Rust code, so the Rust test/clippy/fmt suites are unaffected; CI still runs them on this PR.
