### PR TITLE
ci: speed up Docker builds with native arm64 runners and cargo-chef caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@ output
 .git
 *.md
 !README.md
+
+# Non-build assets kept out of the build context so doc/example changes don't
+# invalidate the cached compile layer.
+examples
+scripts
+.config
+preview.png

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,29 +5,104 @@ on:
     tags:
       - '*'
     branches:
-      - '**'
+      - main
   workflow_dispatch:
+
+# Cancel superseded runs for the same ref so overlapping pushes don't queue up
+# hour-long builds against each other.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
-    name: Build and push Docker image
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+
+      - name: Docker labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Each platform builds natively (arm64 on an arm64 runner instead of under
+      # QEMU emulation) and caches to a platform-scoped registry ref.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge and push manifest
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: read
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -48,13 +123,12 @@ jobs:
             type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM rust:1.91-slim-bookworm AS builder
+# syntax=docker/dockerfile:1
 
+FROM rust:1.91-slim-bookworm AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
 
+# Compute a dependency recipe that only changes when the dependency graph does,
+# so source-only edits reuse the cached dependency build below.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
-
-COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
-COPY crates crates
-COPY bifrost bifrost
-
-RUN RUSTFLAGS="-C codegen-units=1" CARGO_PROFILE_RELEASE_LTO=true cargo build --release --bin heimdall
+# Build and cache dependencies first. Release optimization flags (fat LTO,
+# codegen-units = 1) are defined once in Cargo.toml's [profile.release].
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin heimdall
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
## What changed? Why?

Docker builds were taking 60 to 66 minutes because the linux/arm64 build ran under QEMU, the GitHub Actions cache repeatedly failed with `not_found`, and source changes invalidated the full Rust compile layer.

This PR builds each architecture on a native runner, uses platform-scoped GHCR registry caches, separates Rust dependency compilation with cargo-chef, removes duplicated release flags, narrows Docker pushes to main and tags, and cancels superseded runs. The runtime image, entrypoint, and amd64/arm64 output are unchanged.

## Notes to reviewers

- The first build after merging will populate the new registry caches.
- `ubuntu-24.04-arm` is required for the native arm64 job.
- The Dockerfile still uses the release profile from `Cargo.toml`: fat LTO, one codegen unit, and non-incremental compilation.
- The local environment has no Docker daemon, so no local image build was possible.

## How has it been tested?

- `actionlint .github/workflows/docker.yml`: 0 findings
- `python3` YAML parse: passed; triggers and concurrency verified
- `cargo metadata`: passed; `heimdall` binary target confirmed
- Inspected `Cargo.toml` release profile: optimization settings preserved
- Docker image build: not run locally because the Docker daemon is unavailable
