### PR TITLE
fix(bifrost): do not create ~/.bash_profile during install

### DIFF
--- a/bifrost/install
+++ b/bifrost/install
@@ -21,10 +21,14 @@ if [[ ":$PATH:" != *":${BIFROST_BIN_DIR}:"* ]]; then
             echo >> $SHELL_PROFILE && echo "export PATH=\"\$PATH:$BIFROST_BIN_DIR\"" >> $SHELL_PROFILE
             ;;
         */bash)
-            SHELL_PROFILE=$HOME/.bashrc
-            echo >> $SHELL_PROFILE && echo "export PATH=\"\$PATH:$BIFROST_BIN_DIR\"" >> $SHELL_PROFILE
-            SHELL_PROFILE=$HOME/.bash_profile
-            echo >> $SHELL_PROFILE && echo "export PATH=\"\$PATH:$BIFROST_BIN_DIR\"" >> $SHELL_PROFILE
+            # Only append to bash profiles that already exist. Using `>>` on a
+            # missing ~/.bash_profile would create it, and bash login shells then
+            # read it instead of ~/.profile, silently dropping the user's startup
+            # configuration (see issue #707).
+            for SHELL_PROFILE in "$HOME/.bashrc" "$HOME/.bash_profile"; do
+                [ -f "$SHELL_PROFILE" ] || continue
+                echo >> "$SHELL_PROFILE" && echo "export PATH=\"\$PATH:$BIFROST_BIN_DIR\"" >> "$SHELL_PROFILE"
+            done
             ;;
         */fish)
             SHELL_PROFILE=$HOME/.config/fish/config.fish

--- a/bifrost/tests/profile-test
+++ b/bifrost/tests/profile-test
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Regression test for issue #707.
+#
+# The bifrost installer must NOT create ~/.bash_profile when it is absent
+# (doing so shadows ~/.profile for bash login shells), but it MUST still add
+# bifrost to the PATH in any bash profile that already exists.
+#
+# The test drives the real `bifrost/install` script against an isolated $HOME
+# with the network/binary steps stubbed out, so only the shell-profile logic
+# runs. Run with: bash bifrost/tests/profile-test
+set -euo pipefail
+
+INSTALL_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/install"
+EXPORT_LINE='export PATH="$PATH:'
+
+pass=0
+fail=0
+ok()   { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# Runs the installer with an isolated HOME and no real network/binary work.
+run_installer() {
+    local home="$1"
+    local stub
+    stub="$(mktemp -d)"
+    # Stub `curl` so it just materializes the file passed after `-o`, letting the
+    # subsequent `chmod +x` succeed without any network access.
+    cat > "$stub/curl" <<'EOF'
+#!/bin/sh
+out=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        *)  shift ;;
+    esac
+done
+[ -n "$out" ] && : > "$out"
+exit 0
+EOF
+    chmod +x "$stub/curl"
+
+    HOME="$home" \
+    BIFROST_PATH="$home/.bifrost" \
+    SHELL="/bin/bash" \
+    PATH="$stub:$PATH" \
+        bash "$INSTALL_SCRIPT" >/dev/null 2>&1
+    rm -rf "$stub"
+}
+
+# --- Case 1: no bash profiles exist -> ~/.bash_profile must NOT be created ---
+home="$(mktemp -d)"
+run_installer "$home"
+if [ ! -e "$home/.bash_profile" ]; then
+    ok "absent ~/.bash_profile is not created"
+else
+    bad "installer created ~/.bash_profile when it did not exist"
+fi
+rm -rf "$home"
+
+# --- Case 2: only ~/.bashrc exists -> it gets the PATH export, no bash_profile ---
+home="$(mktemp -d)"
+: > "$home/.bashrc"
+run_installer "$home"
+if grep -qF "$EXPORT_LINE" "$home/.bashrc"; then
+    ok "existing ~/.bashrc receives the PATH export"
+else
+    bad "existing ~/.bashrc was not updated"
+fi
+if [ ! -e "$home/.bash_profile" ]; then
+    ok "~/.bash_profile still not created when only ~/.bashrc exists"
+else
+    bad "installer created ~/.bash_profile when only ~/.bashrc existed"
+fi
+rm -rf "$home"
+
+# --- Case 3: ~/.bash_profile exists -> it gets the PATH export ---
+home="$(mktemp -d)"
+: > "$home/.bashrc"
+: > "$home/.bash_profile"
+run_installer "$home"
+if grep -qF "$EXPORT_LINE" "$home/.bash_profile"; then
+    ok "existing ~/.bash_profile receives the PATH export"
+else
+    bad "existing ~/.bash_profile was not updated"
+fi
+rm -rf "$home"
+
+echo "----"
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What changed? Why?

Fixes #707.

The `bifrost/install` script appended the PATH export to **both** `~/.bashrc` and `~/.bash_profile` using `>>`. Because `>>` creates its target when absent, running the installer created `~/.bash_profile` on systems that did not have one. On Debian/Ubuntu/WSL, `~/.profile` normally sources `~/.bashrc`, but a bash **login** shell reads `~/.bash_profile` first and stops there — so once the installer created that file, the user's `~/.profile`/`~/.bashrc` startup configuration was silently dropped after the next login.

The actual source matched the issue report (the bash `case` branch unconditionally wrote to both files). The fix loops over `~/.bashrc` and `~/.bash_profile` and only appends to a profile that **already exists**, so the installer never creates `~/.bash_profile` as a side effect. The existing PATH string, the `zsh` (`~/.zshrc`) and `fish` (`config.fish`) branches, and the "already on PATH" guard are all unchanged.

## Notes to reviewers

- `bifrost/install` — replaced the two unconditional `>>` writes in the `*/bash)` branch with a loop that skips non-existent profiles (`[ -f "$SHELL_PROFILE" ] || continue`) and quotes the profile path. Only the bash branch changed.
- `bifrost/tests/profile-test` — new deterministic regression test (extensionless to match repo shell-script convention and avoid the `*.sh` entry in `.gitignore`). It runs the **real** install script against an isolated `$HOME` with `curl`/binary steps stubbed, so only the shell-profile logic executes.

## How has it been tested?

- `bash -n bifrost/install` and `bash -n bifrost/tests/profile-test` — syntax valid.
- `bash bifrost/tests/profile-test` — 4/4 assertions pass:
  1. absent `~/.bash_profile` is **not** created,
  2. existing `~/.bashrc` receives the PATH export,
  3. `~/.bash_profile` is still not created when only `~/.bashrc` exists,
  4. existing `~/.bash_profile` receives the PATH export.
- Ran the same test against the pre-fix `install` script to confirm it is meaningful: it fails cases 1 and 3 (reproducing the reported bug) and passes after the fix.
- Change is shell-only; no Rust sources were touched, so the workspace `cargo` checks are unaffected.
