### PR TITLE
feat(decompile): infer semantic storage layouts

### DIFF
--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -70,6 +70,78 @@ impl BinaryOp {
     }
 }
 
+/// A semantic path from a root storage slot to a value.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum StoragePath {
+    Slot { slot: Box<Expr> },
+    Mapping { parent: Box<StoragePath>, key: Box<Expr> },
+    DynamicArray { parent: Box<StoragePath>, index: Box<Expr> },
+    Field { parent: Box<StoragePath>, offset: U256 },
+}
+
+impl StoragePath {
+    fn collect_identifiers(&self, identifiers: &mut HashSet<String>) {
+        match self {
+            Self::Slot { slot } => slot.collect_identifiers(identifiers),
+            Self::Mapping { parent, key } => {
+                parent.collect_identifiers(identifiers);
+                key.collect_identifiers(identifiers);
+            }
+            Self::DynamicArray { parent, index } => {
+                parent.collect_identifiers(identifiers);
+                index.collect_identifiers(identifiers);
+            }
+            Self::Field { parent, .. } => parent.collect_identifiers(identifiers),
+        }
+    }
+
+    fn visit_mut(&mut self, visitor: &mut impl FnMut(&mut Expr)) {
+        match self {
+            Self::Slot { slot } => slot.visit_mut(visitor),
+            Self::Mapping { parent, key } => {
+                parent.visit_mut(visitor);
+                key.visit_mut(visitor);
+            }
+            Self::DynamicArray { parent, index } => {
+                parent.visit_mut(visitor);
+                index.visit_mut(visitor);
+            }
+            Self::Field { parent, .. } => parent.visit_mut(visitor),
+        }
+    }
+
+    fn simplify(self) -> Self {
+        match self {
+            Self::Slot { slot } => Self::Slot { slot: Box::new(slot.simplify()) },
+            Self::Mapping { parent, key } => {
+                Self::Mapping { parent: Box::new(parent.simplify()), key: Box::new(key.simplify()) }
+            }
+            Self::DynamicArray { parent, index } => Self::DynamicArray {
+                parent: Box::new(parent.simplify()),
+                index: Box::new(index.simplify()),
+            },
+            Self::Field { parent, offset } => {
+                Self::Field { parent: Box::new(parent.simplify()), offset }
+            }
+        }
+    }
+
+    fn render_slot(&self) -> String {
+        match self {
+            Self::Slot { slot } => slot.render(),
+            Self::Mapping { parent, key } => {
+                format!("keccak256({}, {})", key.render(), parent.render_slot())
+            }
+            Self::DynamicArray { parent, index } => {
+                format!("keccak256({}) + {}", parent.render_slot(), index.render())
+            }
+            Self::Field { parent, offset } => {
+                format!("{} + {}", parent.render_slot(), encode_hex_reduced(*offset))
+            }
+        }
+    }
+}
+
 /// A small, lossless expression tree used between analysis and source rendering.
 ///
 /// `Raw` is an intentional escape hatch for expressions that do not have a source-level mapping
@@ -88,6 +160,8 @@ pub(crate) enum Expr {
     Index { base: Box<Expr>, index: Box<Expr> },
     Slice { base: Box<Expr>, start: Box<Expr>, end: Box<Expr> },
     Member { base: Box<Expr>, member: String },
+    Keccak { offset: Box<Expr>, size: Box<Expr>, preimage: Option<Vec<Expr>> },
+    StorageAccess(Box<StoragePath>),
     Cast { ty: String, value: Box<Expr> },
     Call { callee: String, args: Vec<Expr> },
 }
@@ -195,14 +269,17 @@ impl Expr {
             opcodes::SELFBALANCE => Self::identifier("address(this).balance"),
             opcodes::GASPRICE => Self::identifier("tx.gasprice"),
             opcodes::GAS => Self::Call { callee: "gasleft".to_string(), args: vec![] },
-            opcodes::SLOAD => Self::index("storage", input(0)),
+            opcodes::SLOAD => {
+                Self::StorageAccess(Box::new(StoragePath::Slot { slot: Box::new(input(0)) }))
+            }
             opcodes::TLOAD => Self::index("transient", input(0)),
             opcodes::MLOAD => Self::index("memory", input(0)),
             opcodes::MSIZE => Self::identifier("memory.length"),
             opcodes::RETURNDATASIZE => Self::identifier("ret0.length"),
-            opcodes::SHA3 => Self::Call {
-                callee: "keccak256".to_string(),
-                args: vec![Self::index("memory", input(0))],
+            opcodes::SHA3 => Self::Keccak {
+                offset: Box::new(input(0)),
+                size: Box::new(input(1)),
+                preimage: None,
             },
             opcodes::BLOCKHASH => {
                 Self::Call { callee: "blockhash".to_string(), args: vec![input(0)] }
@@ -280,6 +357,16 @@ impl Expr {
                 end.collect_identifiers(identifiers);
             }
             Self::Member { base, .. } => base.collect_identifiers(identifiers),
+            Self::Keccak { offset, size, preimage } => {
+                offset.collect_identifiers(identifiers);
+                size.collect_identifiers(identifiers);
+                if let Some(preimage) = preimage {
+                    for value in preimage {
+                        value.collect_identifiers(identifiers);
+                    }
+                }
+            }
+            Self::StorageAccess(path) => path.collect_identifiers(identifiers),
             Self::Call { args, .. } => {
                 for arg in args {
                     arg.collect_identifiers(identifiers);
@@ -307,6 +394,16 @@ impl Expr {
                 end.visit_mut(visitor);
             }
             Self::Member { base, .. } => base.visit_mut(visitor),
+            Self::Keccak { offset, size, preimage } => {
+                offset.visit_mut(visitor);
+                size.visit_mut(visitor);
+                if let Some(preimage) = preimage {
+                    for value in preimage {
+                        value.visit_mut(visitor);
+                    }
+                }
+            }
+            Self::StorageAccess(path) => path.visit_mut(visitor),
             Self::Call { args, .. } => {
                 for arg in args {
                     arg.visit_mut(visitor);
@@ -409,6 +506,12 @@ impl Expr {
             Self::Member { base, member } => {
                 Self::Member { base: Box::new(base.simplify()), member }
             }
+            Self::Keccak { offset, size, preimage } => Self::Keccak {
+                offset: Box::new(offset.simplify()),
+                size: Box::new(size.simplify()),
+                preimage: preimage.map(|values| values.into_iter().map(Self::simplify).collect()),
+            },
+            Self::StorageAccess(path) => Self::StorageAccess(Box::new(path.simplify())),
             Self::Cast { ty, value } => Self::Cast { ty, value: Box::new(value.simplify()) },
             Self::Call { callee, args } => {
                 Self::Call { callee, args: args.into_iter().map(Self::simplify).collect() }
@@ -454,6 +557,18 @@ impl Expr {
                 format!("{}[{}:{}]", base.render(), start.render(), end.render())
             }
             Self::Member { base, member } => format!("{}.{}", base.render(), member),
+            Self::Keccak { offset, size, preimage } => match preimage {
+                Some(values) => format!(
+                    "keccak256({})",
+                    values.iter().map(Self::render).collect::<Vec<_>>().join(", ")
+                ),
+                None => format!(
+                    "keccak256(memory[{}:{}])",
+                    offset.render(),
+                    Self::binary(BinaryOp::Add, *offset.clone(), *size.clone()).render()
+                ),
+            },
+            Self::StorageAccess(path) => format!("storage[{}]", path.render_slot()),
             Self::Cast { ty, value } => format!("{ty}({})", value.render()),
             Self::Call { callee, args } => format!(
                 "{callee}({})",

--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -652,11 +652,14 @@ pub(crate) enum Statement {
         comment: Option<String>,
     },
     Expression(Expr),
+    /// Captures a SHA3 operation while its memory preimage is still available.
+    KeccakSnapshot(Expr),
     AssemblyAssign {
         target: String,
         function: String,
         args: Vec<Expr>,
     },
+    Noop,
     CloseBlock,
 }
 
@@ -679,7 +682,9 @@ impl Statement {
                     reason.visit_mut(visitor);
                 }
             }
-            Self::Return(value) | Self::Expression(value) => value.visit_mut(visitor),
+            Self::Return(value) | Self::Expression(value) | Self::KeccakSnapshot(value) => {
+                value.visit_mut(visitor)
+            }
             Self::Emit { args, .. } | Self::AssemblyAssign { args, .. } => {
                 for arg in args {
                     arg.visit_mut(visitor);
@@ -697,7 +702,7 @@ impl Statement {
                     value.visit_mut(visitor);
                 }
             }
-            Self::CloseBlock => {}
+            Self::Noop | Self::CloseBlock => {}
         }
     }
 
@@ -734,6 +739,7 @@ impl Statement {
                 }
             }
             Self::Expression(value) => Self::Expression(value.simplify()),
+            Self::KeccakSnapshot(value) => Self::KeccakSnapshot(value.simplify()),
             Self::AssemblyAssign { target, function, args } => Self::AssemblyAssign {
                 target,
                 function,
@@ -819,6 +825,7 @@ impl Statement {
                 "assembly {{ {target} := {function}({}) }}",
                 args.iter().map(Expr::render).collect::<Vec<_>>().join(", ")
             ),
+            Self::KeccakSnapshot(_) | Self::Noop => String::new(),
             Self::CloseBlock => "}".to_string(),
         }
     }

--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -77,6 +77,7 @@ pub(crate) enum StoragePath {
     Mapping { parent: Box<StoragePath>, key: Box<Expr> },
     DynamicArray { parent: Box<StoragePath>, index: Box<Expr> },
     Field { parent: Box<StoragePath>, offset: U256 },
+    PackedField { parent: Box<StoragePath>, bit_offset: u16, bit_width: u16 },
 }
 
 impl StoragePath {
@@ -91,7 +92,9 @@ impl StoragePath {
                 parent.collect_identifiers(identifiers);
                 index.collect_identifiers(identifiers);
             }
-            Self::Field { parent, .. } => parent.collect_identifiers(identifiers),
+            Self::Field { parent, .. } | Self::PackedField { parent, .. } => {
+                parent.collect_identifiers(identifiers)
+            }
         }
     }
 
@@ -106,7 +109,9 @@ impl StoragePath {
                 parent.visit_mut(visitor);
                 index.visit_mut(visitor);
             }
-            Self::Field { parent, .. } => parent.visit_mut(visitor),
+            Self::Field { parent, .. } | Self::PackedField { parent, .. } => {
+                parent.visit_mut(visitor)
+            }
         }
     }
 
@@ -123,6 +128,9 @@ impl StoragePath {
             Self::Field { parent, offset } => {
                 Self::Field { parent: Box::new(parent.simplify()), offset }
             }
+            Self::PackedField { parent, bit_offset, bit_width } => {
+                Self::PackedField { parent: Box::new(parent.simplify()), bit_offset, bit_width }
+            }
         }
     }
 
@@ -137,6 +145,9 @@ impl StoragePath {
             }
             Self::Field { parent, offset } => {
                 format!("{} + {}", parent.render_slot(), encode_hex_reduced(*offset))
+            }
+            Self::PackedField { parent, bit_offset, bit_width } => {
+                format!("packed({}, {}, {})", parent.render_slot(), bit_offset, bit_width)
             }
         }
     }

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -42,6 +42,18 @@ fn is_storage_access(expr: &Expr) -> bool {
     matches!(expr, Expr::StorageAccess(_))
 }
 
+fn path_has_packed_width(path: &super::ir::StoragePath, width: u16) -> bool {
+    match path {
+        super::ir::StoragePath::PackedField { parent, bit_width, .. } => {
+            *bit_width == width || path_has_packed_width(parent, width)
+        }
+        super::ir::StoragePath::Mapping { parent, .. } |
+        super::ir::StoragePath::DynamicArray { parent, .. } |
+        super::ir::StoragePath::Field { parent, .. } => path_has_packed_width(parent, width),
+        super::ir::StoragePath::Slot { .. } => false,
+    }
+}
+
 fn has_binary_literal(statements: &[Statement], op: BinaryOp, literal: U256) -> bool {
     find_expression(statements, |expr| {
         matches!(
@@ -113,7 +125,6 @@ impl PostprocessOrchestrator {
     pub(crate) fn register_passes(&mut self) -> Result<(), Error> {
         match self.typ {
             AnalyzerType::Solidity => {
-                self.ir_passes.push(storage_inference_postprocessor);
                 self.ir_passes.push(bitwise_mask_postprocessor);
                 self.ir_passes.push(arithmetic_postprocessor);
                 self.ir_passes.push(memory_postprocessor);
@@ -175,6 +186,14 @@ impl PostprocessOrchestrator {
             (String::from(".chainid"), String::from("uint256")),
         ]);
 
+        // Storage inference must run before getter detection and before memory accesses are
+        // renamed.
+        if self.typ == AnalyzerType::Solidity {
+            for statement in &mut function.statements {
+                storage_inference_postprocessor(statement, &mut state)?;
+            }
+        }
+
         // Detect simple getters and Solidity's RLP-backed string pattern directly on the IR.
         if !function.payable && (function.pure || function.view) && function.arguments.is_empty() {
             let returned_storage = function.statements.iter().find_map(|statement| {
@@ -186,7 +205,11 @@ impl PostprocessOrchestrator {
                 state.maybe_getter_for = Some(storage.clone());
 
                 if has_binary_literal(&function.statements, BinaryOp::Mul, U256::from(0x100)) &&
-                    has_binary_literal(&function.statements, BinaryOp::BitAnd, U256::from(1))
+                    (has_binary_literal(&function.statements, BinaryOp::BitAnd, U256::from(1)) ||
+                        find_expression(&function.statements, |expr| {
+                            matches!(expr, Expr::StorageAccess(path) if path_has_packed_width(path, 8))
+                        })
+                        .is_some())
                 {
                     function.returns = Some(String::from("string memory"));
                     function.statements = vec![Statement::Return(Expr::Call {
@@ -263,5 +286,42 @@ impl PostprocessOrchestrator {
         );
 
         Ok(self.state.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ir::StoragePath;
+
+    #[test]
+    fn recovers_mapping_through_full_pipeline() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.analyzer_type = AnalyzerType::Solidity;
+        function.statements = vec![
+            Statement::Assign {
+                target: Expr::index("memory", Expr::Literal(U256::ZERO)),
+                value: Expr::identifier("msg.sender"),
+            },
+            Statement::Assign {
+                target: Expr::index("memory", Expr::Literal(U256::from(32))),
+                value: Expr::Literal(U256::from(5)),
+            },
+            Statement::Return(Expr::StorageAccess(Box::new(StoragePath::Slot {
+                slot: Box::new(Expr::Keccak {
+                    offset: Box::new(Expr::Literal(U256::ZERO)),
+                    size: Box::new(Expr::Literal(U256::from(64))),
+                    preimage: None,
+                }),
+            }))),
+        ];
+
+        let mut orchestrator = PostprocessOrchestrator::new(AnalyzerType::Solidity).unwrap();
+        let state = orchestrator.postprocess(&mut function).unwrap();
+        assert_eq!(function.logic, vec!["return storage_map_a[msg.sender];"]);
+        assert_eq!(
+            state.storage_type_map.get("storage_map_a"),
+            Some(&"mapping(address => bytes32)".to_string())
+        );
     }
 }

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -70,6 +70,10 @@ fn has_binary_literal(statements: &[Statement], op: BinaryOp, literal: U256) -> 
 /// State shared between postprocessors
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PostprocessorState {
+    /// Preimages captured when SHA3 executes, keyed by the unresolved hash expression.
+    pub keccak_preimages: HashMap<Expr, Vec<Vec<Expr>>>,
+    /// Parent Keccak histories used to isolate conditional branches.
+    pub keccak_preimage_scopes: Vec<HashMap<Expr, Vec<Vec<Expr>>>>,
     /// Symbolic values written to constant memory offsets, used for Keccak preimages.
     pub symbolic_memory: HashMap<U256, Expr>,
     /// Parent memory states used to prevent writes from leaking out of conditional branches.

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -8,8 +8,8 @@ use crate::{
     interfaces::AnalyzedFunction,
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, eliminate_dead_variables,
-        memory_postprocessor, storage_postprocessor, transient_postprocessor,
-        variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
+        memory_postprocessor, storage_inference_postprocessor, storage_postprocessor,
+        transient_postprocessor, variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
     },
     Error,
 };
@@ -39,7 +39,7 @@ fn find_expression(
 }
 
 fn is_storage_access(expr: &Expr) -> bool {
-    matches!(expr, Expr::Index { base, .. } if base.render() == "storage")
+    matches!(expr, Expr::StorageAccess(_))
 }
 
 fn has_binary_literal(statements: &[Statement], op: BinaryOp, literal: U256) -> bool {
@@ -58,6 +58,8 @@ fn has_binary_literal(statements: &[Statement], op: BinaryOp, literal: U256) -> 
 /// State shared between postprocessors
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PostprocessorState {
+    /// Symbolic values written to constant memory offsets, used for Keccak preimages.
+    pub symbolic_memory: HashMap<U256, Expr>,
     /// A mapping from memory locations to their corresponding variable names
     pub memory_map: HashMap<Expr, Expr>,
     /// A mapping which holds the last assigned value for a given variable
@@ -109,6 +111,7 @@ impl PostprocessOrchestrator {
     pub(crate) fn register_passes(&mut self) -> Result<(), Error> {
         match self.typ {
             AnalyzerType::Solidity => {
+                self.ir_passes.push(storage_inference_postprocessor);
                 self.ir_passes.push(bitwise_mask_postprocessor);
                 self.ir_passes.push(arithmetic_postprocessor);
                 self.ir_passes.push(memory_postprocessor);

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -60,6 +60,8 @@ fn has_binary_literal(statements: &[Statement], op: BinaryOp, literal: U256) -> 
 pub(crate) struct PostprocessorState {
     /// Symbolic values written to constant memory offsets, used for Keccak preimages.
     pub symbolic_memory: HashMap<U256, Expr>,
+    /// Parent memory states used to prevent writes from leaking out of conditional branches.
+    pub symbolic_memory_scopes: Vec<HashMap<U256, Expr>>,
     /// A mapping from memory locations to their corresponding variable names
     pub memory_map: HashMap<Expr, Expr>,
     /// A mapping which holds the last assigned value for a given variable

--- a/crates/decompile/src/utils/heuristics/arguments.rs
+++ b/crates/decompile/src/utils/heuristics/arguments.rs
@@ -2,8 +2,6 @@ use futures::future::BoxFuture;
 use hashbrown::HashSet;
 
 use alloy::primitives::U256;
-use eyre::eyre;
-use heimdall_common::utils::strings::find_balanced_encapsulator;
 use heimdall_vm::core::{
     opcodes::{opcode_name, CALLDATALOAD, ISZERO},
     types::{byte_size_to_type, convert_bitmask},
@@ -17,7 +15,7 @@ use crate::{
         ir::{Expr, Statement},
     },
     interfaces::{AnalyzedFunction, CalldataFrame, TypeHeuristic},
-    utils::constants::{AND_BITMASK_REGEX, AND_BITMASK_REGEX_2, STORAGE_ACCESS_REGEX},
+    utils::constants::{AND_BITMASK_REGEX, AND_BITMASK_REGEX_2},
     Error,
 };
 
@@ -199,22 +197,6 @@ pub(crate) fn argument_heuristic<'a>(
                     // convert the cast size to a string
                     let (_, cast_types) = byte_size_to_type(byte_size);
                     function.returns = Some(cast_types[0].to_string());
-                }
-
-                // check if this is a state getter
-                if function.arguments.is_empty() {
-                    if let Some(storage_access) = STORAGE_ACCESS_REGEX
-                        .find(&return_memory_operations_solidified)
-                        .unwrap_or(None)
-                    {
-                        let storage_access = storage_access.as_str();
-                        let access_range =
-                            find_balanced_encapsulator(storage_access, ('[', ']'))
-                                .map_err(|e| eyre!("failed to find access range: {e}"))?;
-
-                        function.maybe_getter_for =
-                            Some(format!("storage[{}]", &storage_access[access_range]));
-                    }
                 }
 
                 debug!(

--- a/crates/decompile/src/utils/heuristics/solidity.rs
+++ b/crates/decompile/src/utils/heuristics/solidity.rs
@@ -23,6 +23,15 @@ pub(crate) fn solidity_heuristic<'a>(
         let instruction = &state.last_instruction;
 
         match instruction.opcode {
+            // SHA3: retain a point-in-time memory snapshot for storage-path recovery.
+            0x20 => {
+                function.push_statement(Statement::KeccakSnapshot(Expr::Keccak {
+                    offset: Box::new(Expr::from_opcode(&instruction.input_operations[0])),
+                    size: Box::new(Expr::from_opcode(&instruction.input_operations[1])),
+                    preimage: None,
+                }));
+            }
+
             // CALLDATACOPY
             0x37 => {
                 let source_offset = Expr::from_opcode(&instruction.input_operations[1]);

--- a/crates/decompile/src/utils/heuristics/solidity.rs
+++ b/crates/decompile/src/utils/heuristics/solidity.rs
@@ -7,7 +7,7 @@ use heimdall_vm::core::vm::State;
 use crate::{
     core::{
         analyze::AnalyzerState,
-        ir::{BinaryOp, Expr, Statement},
+        ir::{BinaryOp, Expr, Statement, StoragePath},
     },
     interfaces::{AnalyzedFunction, StorageFrame},
     utils::constants::VARIABLE_SIZE_CHECK_REGEX,
@@ -94,10 +94,9 @@ pub(crate) fn solidity_heuristic<'a>(
             // SSTORE
             0x55 => {
                 function.push_statement(Statement::Assign {
-                    target: Expr::index(
-                        "storage",
-                        Expr::from_opcode(&instruction.input_operations[0]),
-                    ),
+                    target: Expr::StorageAccess(Box::new(StoragePath::Slot {
+                        slot: Box::new(Expr::from_opcode(&instruction.input_operations[0])),
+                    })),
                     value: Expr::from_opcode(&instruction.input_operations[1]),
                 });
             }

--- a/crates/decompile/src/utils/postprocessors/deadcode.rs
+++ b/crates/decompile/src/utils/postprocessors/deadcode.rs
@@ -50,7 +50,9 @@ fn statement_usages(statement: &Statement) -> HashSet<String> {
                 collect(reason);
             }
         }
-        Statement::Return(value) | Statement::Expression(value) => collect(value),
+        Statement::Return(value) |
+        Statement::Expression(value) |
+        Statement::KeccakSnapshot(value) => collect(value),
         Statement::Emit { args, .. } | Statement::AssemblyAssign { args, .. } => {
             for arg in args {
                 collect(arg);
@@ -68,7 +70,7 @@ fn statement_usages(statement: &Statement) -> HashSet<String> {
                 collect(value);
             }
         }
-        Statement::CloseBlock => {}
+        Statement::Noop | Statement::CloseBlock => {}
     }
 
     usages
@@ -117,7 +119,9 @@ pub(crate) fn eliminate_dead_variables(
         .statements
         .drain(..)
         .enumerate()
-        .filter_map(|(idx, statement)| (!dead.contains(&idx)).then_some(statement))
+        .filter_map(|(idx, statement)| {
+            (!dead.contains(&idx) && !matches!(statement, Statement::Noop)).then_some(statement)
+        })
         .collect();
     Ok(())
 }

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -10,6 +10,7 @@ mod bitwise;
 mod deadcode;
 mod memory;
 mod storage;
+mod storage_inference;
 mod transient;
 mod variable;
 
@@ -19,6 +20,7 @@ pub(crate) use bitwise::bitwise_mask_postprocessor;
 pub(crate) use deadcode::eliminate_dead_variables;
 pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
+pub(crate) use storage_inference::storage_inference_postprocessor;
 pub(crate) use transient::transient_postprocessor;
 pub(crate) use variable::variable_postprocessor;
 

--- a/crates/decompile/src/utils/postprocessors/storage.rs
+++ b/crates/decompile/src/utils/postprocessors/storage.rs
@@ -2,15 +2,11 @@ use heimdall_common::utils::strings::base26_encode;
 
 use crate::{
     core::{
-        ir::{BinaryOp, Expr, Statement},
+        ir::{BinaryOp, Expr, Statement, StoragePath},
         postprocess::PostprocessorState,
     },
     Error,
 };
-
-fn is_storage_base(expr: &Expr) -> bool {
-    matches!(expr, Expr::Raw(name) | Expr::Identifier(name) if name == "storage")
-}
 
 fn expression_type(expr: &Expr, state: &PostprocessorState) -> String {
     match expr {
@@ -28,38 +24,102 @@ fn expression_type(expr: &Expr, state: &PostprocessorState) -> String {
     }
 }
 
-fn mapping_key(slot: &Expr) -> Option<Expr> {
-    match slot {
-        Expr::Call { callee, args } if callee == "keccak256" => args.first().cloned(),
+fn same_layout(a: &StoragePath, b: &StoragePath) -> bool {
+    match (a, b) {
+        (StoragePath::Slot { slot: a }, StoragePath::Slot { slot: b }) => a == b,
+        (StoragePath::Mapping { parent: a, .. }, StoragePath::Mapping { parent: b, .. }) |
+        (
+            StoragePath::DynamicArray { parent: a, .. },
+            StoragePath::DynamicArray { parent: b, .. },
+        ) => same_layout(a, b),
+        (
+            StoragePath::Field { parent: a, offset: a_offset },
+            StoragePath::Field { parent: b, offset: b_offset },
+        ) => a_offset == b_offset && same_layout(a, b),
+        _ => false,
+    }
+}
+
+fn is_collection(path: &StoragePath) -> bool {
+    match path {
+        StoragePath::Slot { .. } => false,
+        StoragePath::Mapping { .. } | StoragePath::DynamicArray { .. } => true,
+        StoragePath::Field { parent, .. } => is_collection(parent),
+    }
+}
+
+fn replacement_root(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(name) => Some(name.clone()),
+        Expr::Index { base, .. } | Expr::Member { base, .. } => replacement_root(base),
         _ => None,
     }
 }
 
-/// Replaces storage accesses with stable state-variable references and infers their types.
+fn render_path(path: &StoragePath, root: &str) -> Expr {
+    match path {
+        StoragePath::Slot { .. } => Expr::identifier(root),
+        StoragePath::Mapping { parent, key } => {
+            Expr::Index { base: Box::new(render_path(parent, root)), index: key.clone() }
+        }
+        StoragePath::DynamicArray { parent, index } => {
+            Expr::Index { base: Box::new(render_path(parent, root)), index: index.clone() }
+        }
+        StoragePath::Field { parent, offset } => Expr::Member {
+            base: Box::new(render_path(parent, root)),
+            member: format!("field_{offset}"),
+        },
+    }
+}
+
+fn storage_type(path: &StoragePath, leaf: String, state: &PostprocessorState) -> String {
+    match path {
+        StoragePath::Slot { .. } => leaf,
+        StoragePath::Mapping { parent, key } => storage_type(
+            parent,
+            format!("mapping({} => {leaf})", expression_type(key, state)),
+            state,
+        ),
+        StoragePath::DynamicArray { parent, .. } => {
+            storage_type(parent, format!("{leaf}[]"), state)
+        }
+        // Struct synthesis will replace this placeholder in a subsequent layout pass.
+        StoragePath::Field { parent, .. } => storage_type(parent, "bytes32".to_string(), state),
+    }
+}
+
+/// Names semantic storage paths consistently and infers mapping/array declarations.
 pub(crate) fn storage_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
-    statement.visit_exprs_mut(&mut |expr| {
-        let Expr::Index { base, index } = expr else { return };
-        if !is_storage_base(base) {
-            return;
-        }
+    let written_path = match statement {
+        Statement::Assign { target: Expr::StorageAccess(path), .. } => Some((**path).clone()),
+        _ => None,
+    };
 
-        let storage_loc = Expr::Index { base: base.clone(), index: index.clone() };
-        let replacement = state.storage_map.get(&storage_loc).cloned().unwrap_or_else(|| {
-            let suffix = base26_encode(state.storage_map.len() + 1);
-            let replacement = if let Some(key) = mapping_key(index) {
-                Expr::Index {
-                    base: Box::new(Expr::identifier(format!("storage_map_{suffix}"))),
-                    index: Box::new(key),
+    statement.visit_exprs_mut(&mut |expr| {
+        let original = expr.clone();
+        let Expr::StorageAccess(path) = expr else { return };
+        let root = state
+            .storage_map
+            .iter()
+            .find_map(|(known, replacement)| match known {
+                Expr::StorageAccess(known_path) if same_layout(path, known_path) => {
+                    replacement_root(replacement)
                 }
-            } else {
-                Expr::identifier(format!("store_{suffix}"))
-            };
-            state.storage_map.insert(storage_loc, replacement.clone());
-            replacement
-        });
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                let suffix = base26_encode(state.storage_map.len() + 1);
+                if is_collection(path) {
+                    format!("storage_map_{suffix}")
+                } else {
+                    format!("store_{suffix}")
+                }
+            });
+        let replacement = render_path(path, &root);
+        state.storage_map.insert(original, replacement.clone());
         *expr = replacement;
     });
 
@@ -69,29 +129,15 @@ pub(crate) fn storage_postprocessor(
         }
         _ => return Ok(()),
     };
-    let root = match target {
-        Expr::Identifier(name) => name.clone(),
-        Expr::Index { base, .. } => match &**base {
-            Expr::Identifier(name) => name.clone(),
-            _ => return Ok(()),
-        },
-        _ => return Ok(()),
-    };
+    let Some(root) = replacement_root(target) else { return Ok(()) };
     if !root.starts_with("store_") && !root.starts_with("storage_map_") {
         return Ok(())
     }
 
     state.variable_map.insert(target.clone(), value.clone());
-    if root.starts_with("storage_map_") {
-        let key_type = match target {
-            Expr::Index { index, .. } => expression_type(index, state),
-            _ => "bytes32".to_string(),
-        };
-        state
-            .storage_type_map
-            .insert(root, format!("mapping({key_type} => {})", expression_type(value, state)));
-    } else {
-        state.storage_type_map.insert(root, expression_type(value, state));
+    if let Some(path) = written_path {
+        let ty = storage_type(&path, expression_type(value, state), state);
+        state.storage_type_map.insert(root, ty);
     }
 
     Ok(())
@@ -107,7 +153,9 @@ mod tests {
     #[test]
     fn names_storage_slot_and_infers_value_type() {
         let mut statement = Statement::Assign {
-            target: Expr::index("storage", Expr::Literal(U256::ZERO)),
+            target: Expr::StorageAccess(Box::new(StoragePath::Slot {
+                slot: Box::new(Expr::Literal(U256::ZERO)),
+            })),
             value: Expr::identifier("arg0"),
         };
         let mut state = PostprocessorState::default();
@@ -118,13 +166,17 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_mapping_access() {
-        let mut statement = Statement::Return(Expr::index(
-            "storage",
-            Expr::Call { callee: "keccak256".to_string(), args: vec![Expr::identifier("arg0")] },
-        ));
+    fn reuses_mapping_name_across_keys() {
+        let path = |key| StoragePath::Mapping {
+            parent: Box::new(StoragePath::Slot { slot: Box::new(Expr::Literal(U256::from(5))) }),
+            key: Box::new(Expr::identifier(key)),
+        };
+        let mut first = Statement::Return(Expr::StorageAccess(Box::new(path("arg0"))));
+        let mut second = Statement::Return(Expr::StorageAccess(Box::new(path("arg1"))));
         let mut state = PostprocessorState::default();
-        storage_postprocessor(&mut statement, &mut state).unwrap();
-        assert_eq!(statement.render(RenderTarget::Solidity), "return storage_map_a[arg0];");
+        storage_postprocessor(&mut first, &mut state).unwrap();
+        storage_postprocessor(&mut second, &mut state).unwrap();
+        assert_eq!(first.render(RenderTarget::Solidity), "return storage_map_a[arg0];");
+        assert_eq!(second.render(RenderTarget::Solidity), "return storage_map_a[arg1];");
     }
 }

--- a/crates/decompile/src/utils/postprocessors/storage.rs
+++ b/crates/decompile/src/utils/postprocessors/storage.rs
@@ -36,6 +36,10 @@ fn same_layout(a: &StoragePath, b: &StoragePath) -> bool {
             StoragePath::Field { parent: a, offset: a_offset },
             StoragePath::Field { parent: b, offset: b_offset },
         ) => a_offset == b_offset && same_layout(a, b),
+        (
+            StoragePath::PackedField { parent: a, bit_offset: a_offset, bit_width: a_width },
+            StoragePath::PackedField { parent: b, bit_offset: b_offset, bit_width: b_width },
+        ) => a_offset == b_offset && a_width == b_width && same_layout(a, b),
         _ => false,
     }
 }
@@ -44,7 +48,9 @@ fn is_collection(path: &StoragePath) -> bool {
     match path {
         StoragePath::Slot { .. } => false,
         StoragePath::Mapping { .. } | StoragePath::DynamicArray { .. } => true,
-        StoragePath::Field { parent, .. } => is_collection(parent),
+        StoragePath::Field { parent, .. } | StoragePath::PackedField { parent, .. } => {
+            is_collection(parent)
+        }
     }
 }
 
@@ -69,6 +75,16 @@ fn render_path(path: &StoragePath, root: &str) -> Expr {
             base: Box::new(render_path(parent, root)),
             member: format!("field_{offset}"),
         },
+        StoragePath::PackedField { parent, bit_offset, .. } => {
+            if is_collection(parent) {
+                Expr::Member {
+                    base: Box::new(render_path(parent, root)),
+                    member: format!("field_{bit_offset}"),
+                }
+            } else {
+                Expr::identifier(root)
+            }
+        }
     }
 }
 
@@ -85,6 +101,11 @@ fn storage_type(path: &StoragePath, leaf: String, state: &PostprocessorState) ->
         }
         // Struct synthesis will replace this placeholder in a subsequent layout pass.
         StoragePath::Field { parent, .. } => storage_type(parent, "bytes32".to_string(), state),
+        StoragePath::PackedField { parent, bit_width, .. } => {
+            let packed_type =
+                if *bit_width == 160 { "address".to_string() } else { format!("uint{bit_width}") };
+            storage_type(parent, packed_type, state)
+        }
     }
 }
 
@@ -98,6 +119,7 @@ pub(crate) fn storage_postprocessor(
         _ => None,
     };
 
+    let mut observed_paths = Vec::new();
     statement.visit_exprs_mut(&mut |expr| {
         let original = expr.clone();
         let Expr::StorageAccess(path) = expr else { return };
@@ -119,9 +141,15 @@ pub(crate) fn storage_postprocessor(
                 }
             });
         let replacement = render_path(path, &root);
+        observed_paths.push((root, (**path).clone()));
         state.storage_map.insert(original, replacement.clone());
         *expr = replacement;
     });
+
+    for (root, path) in observed_paths {
+        let inferred = storage_type(&path, "bytes32".to_string(), state);
+        state.storage_type_map.entry(root).or_insert(inferred);
+    }
 
     let (target, value) = match statement {
         Statement::Assign { target, value } | Statement::DeclareAssign { target, value, .. } => {

--- a/crates/decompile/src/utils/postprocessors/storage.rs
+++ b/crates/decompile/src/utils/postprocessors/storage.rs
@@ -12,14 +12,21 @@ fn expression_type(expr: &Expr, state: &PostprocessorState) -> String {
     match expr {
         Expr::Cast { ty, .. } => ty.clone(),
         Expr::Identifier(name) => {
-            state.memory_type_map.get(name).cloned().unwrap_or_else(|| "bytes32".to_string())
+            if matches!(name.as_str(), "msg.sender" | "tx.origin" | "address(this)") {
+                "address".to_string()
+            } else {
+                state.memory_type_map.get(name).cloned().unwrap_or_else(|| "bytes32".to_string())
+            }
         }
         Expr::Binary { op, .. }
             if !matches!(op, BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor) =>
         {
             "uint256".to_string()
         }
+        Expr::Bool(_) => "bool".to_string(),
         Expr::Literal(_) => "uint256".to_string(),
+        Expr::Keccak { .. } => "bytes32".to_string(),
+        Expr::Call { callee, .. } if callee == "address" => "address".to_string(),
         _ => "bytes32".to_string(),
     }
 }
@@ -32,10 +39,9 @@ fn same_layout(a: &StoragePath, b: &StoragePath) -> bool {
             StoragePath::DynamicArray { parent: a, .. },
             StoragePath::DynamicArray { parent: b, .. },
         ) => same_layout(a, b),
-        (
-            StoragePath::Field { parent: a, offset: a_offset },
-            StoragePath::Field { parent: b, offset: b_offset },
-        ) => a_offset == b_offset && same_layout(a, b),
+        (StoragePath::Field { parent: a, .. }, StoragePath::Field { parent: b, .. }) => {
+            same_layout(a, b)
+        }
         (
             StoragePath::PackedField { parent: a, bit_offset: a_offset, bit_width: a_width },
             StoragePath::PackedField { parent: b, bit_offset: b_offset, bit_width: b_width },
@@ -191,6 +197,31 @@ mod tests {
         storage_postprocessor(&mut statement, &mut state).unwrap();
         assert_eq!(statement.render(RenderTarget::Solidity), "store_a = arg0;");
         assert_eq!(state.storage_type_map.get("store_a"), Some(&"address".to_string()));
+    }
+
+    #[test]
+    fn infers_nested_mapping_type() {
+        let path = StoragePath::Mapping {
+            parent: Box::new(StoragePath::Mapping {
+                parent: Box::new(StoragePath::Slot {
+                    slot: Box::new(Expr::Literal(U256::from(5))),
+                }),
+                key: Box::new(Expr::identifier("arg0")),
+            }),
+            key: Box::new(Expr::identifier("arg1")),
+        };
+        let mut statement = Statement::Assign {
+            target: Expr::StorageAccess(Box::new(path)),
+            value: Expr::Literal(U256::from(1)),
+        };
+        let mut state = PostprocessorState::default();
+        state.memory_type_map.insert("arg0".to_string(), "address".to_string());
+        state.memory_type_map.insert("arg1".to_string(), "address".to_string());
+        storage_postprocessor(&mut statement, &mut state).unwrap();
+        assert_eq!(
+            state.storage_type_map.get("storage_map_a"),
+            Some(&"mapping(address => mapping(address => uint256))".to_string())
+        );
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/storage_inference.rs
+++ b/crates/decompile/src/utils/postprocessors/storage_inference.rs
@@ -125,6 +125,13 @@ pub(crate) fn storage_inference_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    if matches!(statement, Statement::CloseBlock) {
+        if let Some(parent) = state.symbolic_memory_scopes.pop() {
+            state.symbolic_memory = parent;
+        }
+        return Ok(())
+    }
+
     statement.visit_exprs_mut(&mut |expr| {
         resolve_keccak(expr, &state.symbolic_memory);
         if let Expr::StorageAccess(path) = expr {
@@ -136,6 +143,10 @@ pub(crate) fn storage_inference_postprocessor(
             *expr = Expr::StorageAccess(Box::new(path));
         }
     });
+
+    if matches!(statement, Statement::If { .. } | Statement::IfRevertElse { .. }) {
+        state.symbolic_memory_scopes.push(state.symbolic_memory.clone());
+    }
 
     if let Statement::Assign { target: Expr::Index { base, index }, value } = statement {
         if base.render() == "memory" {
@@ -191,6 +202,20 @@ mod tests {
             Statement::Return(Expr::StorageAccess(path))
                 if matches!(*path, StoragePath::Mapping { .. })
         ));
+    }
+
+    #[test]
+    fn does_not_leak_memory_writes_out_of_branch() {
+        let mut state = PostprocessorState::default();
+        let mut branch = Statement::If { condition: Expr::Bool(true) };
+        storage_inference_postprocessor(&mut branch, &mut state).unwrap();
+        storage_inference_postprocessor(
+            &mut memory_write(0, Expr::identifier("branch_value")),
+            &mut state,
+        )
+        .unwrap();
+        storage_inference_postprocessor(&mut Statement::CloseBlock, &mut state).unwrap();
+        assert!(!state.symbolic_memory.contains_key(&U256::ZERO));
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/storage_inference.rs
+++ b/crates/decompile/src/utils/postprocessors/storage_inference.rs
@@ -1,0 +1,162 @@
+use alloy::primitives::U256;
+
+use crate::{
+    core::{
+        ir::{BinaryOp, Expr, Statement, StoragePath},
+        postprocess::PostprocessorState,
+    },
+    Error,
+};
+
+fn literal_usize(expr: &Expr) -> Option<usize> {
+    match expr {
+        Expr::Literal(value) => (*value).try_into().ok(),
+        _ => None,
+    }
+}
+
+fn resolve_keccak(expr: &mut Expr, memory: &hashbrown::HashMap<U256, Expr>) {
+    let Expr::Keccak { offset, size, preimage } = expr else { return };
+    let (Some(offset), Some(size)) = (literal_usize(offset), literal_usize(size)) else { return };
+    if size == 0 || size > 512 || !size.is_multiple_of(32) {
+        return;
+    }
+
+    let words = (0..size / 32)
+        .map(|word| memory.get(&U256::from(offset + word * 32)).cloned())
+        .collect::<Option<Vec<_>>>();
+    if let Some(words) = words {
+        *preimage = Some(words);
+    }
+}
+
+fn path_from_keccak(expr: &Expr) -> Option<StoragePath> {
+    let Expr::Keccak { preimage: Some(words), .. } = expr else { return None };
+    match words.as_slice() {
+        [root] => Some(StoragePath::DynamicArray {
+            parent: Box::new(path_from_slot(root.clone())),
+            index: Box::new(Expr::Literal(U256::ZERO)),
+        }),
+        [key, root] => Some(StoragePath::Mapping {
+            parent: Box::new(path_from_slot(root.clone())),
+            key: Box::new(key.clone()),
+        }),
+        _ => None,
+    }
+}
+
+fn path_from_slot(slot: Expr) -> StoragePath {
+    if let Some(path) = path_from_keccak(&slot) {
+        return path;
+    }
+
+    if let Expr::Binary { op: BinaryOp::Add, lhs, rhs } = &slot {
+        for (hash, offset) in [(&**lhs, &**rhs), (&**rhs, &**lhs)] {
+            let Expr::Keccak { preimage: Some(words), .. } = hash else { continue };
+            match words.as_slice() {
+                [root] => {
+                    return StoragePath::DynamicArray {
+                        parent: Box::new(path_from_slot(root.clone())),
+                        index: Box::new(offset.clone()),
+                    }
+                }
+                [key, root] => {
+                    let parent = StoragePath::Mapping {
+                        parent: Box::new(path_from_slot(root.clone())),
+                        key: Box::new(key.clone()),
+                    };
+                    if let Expr::Literal(field_offset) = offset {
+                        return StoragePath::Field {
+                            parent: Box::new(parent),
+                            offset: *field_offset,
+                        };
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    StoragePath::Slot { slot: Box::new(slot) }
+}
+
+/// Resolves SHA3 memory preimages and classifies storage expressions into semantic paths.
+pub(crate) fn storage_inference_postprocessor(
+    statement: &mut Statement,
+    state: &mut PostprocessorState,
+) -> Result<(), Error> {
+    statement.visit_exprs_mut(&mut |expr| {
+        resolve_keccak(expr, &state.symbolic_memory);
+        if let Expr::StorageAccess(path) = expr {
+            let StoragePath::Slot { slot } = &**path else { return };
+            *path = Box::new(path_from_slot(*slot.clone()));
+        }
+    });
+
+    if let Statement::Assign { target: Expr::Index { base, index }, value } = statement {
+        if base.render() == "memory" {
+            if let Expr::Literal(offset) = &**index {
+                state.symbolic_memory.insert(*offset, value.clone());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ir::RenderTarget;
+
+    fn memory_write(offset: u64, value: Expr) -> Statement {
+        Statement::Assign {
+            target: Expr::index("memory", Expr::Literal(U256::from(offset))),
+            value,
+        }
+    }
+
+    #[test]
+    fn resolves_mapping_preimage() {
+        let mut state = PostprocessorState::default();
+        storage_inference_postprocessor(
+            &mut memory_write(0, Expr::identifier("msg.sender")),
+            &mut state,
+        )
+        .unwrap();
+        storage_inference_postprocessor(
+            &mut memory_write(32, Expr::Literal(U256::from(5))),
+            &mut state,
+        )
+        .unwrap();
+
+        let mut load = Statement::Return(Expr::StorageAccess(Box::new(StoragePath::Slot {
+            slot: Box::new(Expr::Keccak {
+                offset: Box::new(Expr::Literal(U256::ZERO)),
+                size: Box::new(Expr::Literal(U256::from(64))),
+                preimage: None,
+            }),
+        })));
+        storage_inference_postprocessor(&mut load, &mut state).unwrap();
+        assert_eq!(
+            load.render(RenderTarget::Solidity),
+            "return storage[keccak256(msg.sender, 0x05)];"
+        );
+        assert!(matches!(
+            load,
+            Statement::Return(Expr::StorageAccess(path))
+                if matches!(*path, StoragePath::Mapping { .. })
+        ));
+    }
+
+    #[test]
+    fn recognizes_dynamic_array_index() {
+        let hash = Expr::Keccak {
+            offset: Box::new(Expr::Literal(U256::ZERO)),
+            size: Box::new(Expr::Literal(U256::from(32))),
+            preimage: Some(vec![Expr::Literal(U256::from(7))]),
+        };
+        let path = path_from_slot(Expr::binary(BinaryOp::Add, hash, Expr::identifier("arg0")));
+        assert!(matches!(path, StoragePath::DynamicArray { .. }));
+    }
+}

--- a/crates/decompile/src/utils/postprocessors/storage_inference.rs
+++ b/crates/decompile/src/utils/postprocessors/storage_inference.rs
@@ -45,6 +45,46 @@ fn path_from_keccak(expr: &Expr) -> Option<StoragePath> {
     }
 }
 
+fn cast_width(ty: &str) -> Option<u16> {
+    match ty {
+        "address" => Some(160),
+        "bool" => Some(8),
+        _ => ty
+            .strip_prefix("uint")
+            .or_else(|| ty.strip_prefix("int"))
+            .and_then(|width| width.parse().ok())
+            .or_else(|| {
+                ty.strip_prefix("bytes")
+                    .and_then(|width| width.parse::<u16>().ok())
+                    .map(|width| width * 8)
+            }),
+    }
+}
+
+fn packed_path(expr: &Expr) -> Option<StoragePath> {
+    let Expr::Cast { ty, value } = expr else { return None };
+    let width = cast_width(ty)?;
+    if width >= 256 {
+        return None;
+    }
+
+    match &**value {
+        Expr::StorageAccess(path) => {
+            Some(StoragePath::PackedField { parent: path.clone(), bit_offset: 0, bit_width: width })
+        }
+        Expr::Binary { op: BinaryOp::Shr, lhs, rhs } => {
+            let Expr::StorageAccess(path) = &**lhs else { return None };
+            let Expr::Literal(offset) = &**rhs else { return None };
+            Some(StoragePath::PackedField {
+                parent: path.clone(),
+                bit_offset: (*offset).try_into().ok()?,
+                bit_width: width,
+            })
+        }
+        _ => None,
+    }
+}
+
 fn path_from_slot(slot: Expr) -> StoragePath {
     if let Some(path) = path_from_keccak(&slot) {
         return path;
@@ -88,8 +128,12 @@ pub(crate) fn storage_inference_postprocessor(
     statement.visit_exprs_mut(&mut |expr| {
         resolve_keccak(expr, &state.symbolic_memory);
         if let Expr::StorageAccess(path) = expr {
-            let StoragePath::Slot { slot } = &**path else { return };
-            *path = Box::new(path_from_slot(*slot.clone()));
+            if let StoragePath::Slot { slot } = &**path {
+                *path = Box::new(path_from_slot(*slot.clone()));
+            }
+        }
+        if let Some(path) = packed_path(expr) {
+            *expr = Expr::StorageAccess(Box::new(path));
         }
     });
 
@@ -146,6 +190,31 @@ mod tests {
             load,
             Statement::Return(Expr::StorageAccess(path))
                 if matches!(*path, StoragePath::Mapping { .. })
+        ));
+    }
+
+    #[test]
+    fn recognizes_packed_field() {
+        let mut statement = Statement::Return(Expr::Cast {
+            ty: "address".to_string(),
+            value: Box::new(Expr::Binary {
+                op: BinaryOp::Shr,
+                lhs: Box::new(Expr::StorageAccess(Box::new(StoragePath::Slot {
+                    slot: Box::new(Expr::Literal(U256::from(3))),
+                }))),
+                rhs: Box::new(Expr::Literal(U256::from(32))),
+            }),
+        });
+        storage_inference_postprocessor(&mut statement, &mut PostprocessorState::default())
+            .unwrap();
+        assert!(matches!(
+            statement,
+            Statement::Return(Expr::StorageAccess(path))
+                if matches!(*path, StoragePath::PackedField {
+                    bit_offset: 32,
+                    bit_width: 160,
+                    ..
+                })
         ));
     }
 

--- a/crates/decompile/src/utils/postprocessors/storage_inference.rs
+++ b/crates/decompile/src/utils/postprocessors/storage_inference.rs
@@ -15,7 +15,7 @@ fn literal_usize(expr: &Expr) -> Option<usize> {
     }
 }
 
-fn resolve_keccak(expr: &mut Expr, memory: &hashbrown::HashMap<U256, Expr>) {
+fn capture_keccak(expr: &mut Expr, state: &PostprocessorState) {
     let Expr::Keccak { offset, size, preimage } = expr else { return };
     let (Some(offset), Some(size)) = (literal_usize(offset), literal_usize(size)) else { return };
     if size == 0 || size > 512 || !size.is_multiple_of(32) {
@@ -23,10 +23,20 @@ fn resolve_keccak(expr: &mut Expr, memory: &hashbrown::HashMap<U256, Expr>) {
     }
 
     let words = (0..size / 32)
-        .map(|word| memory.get(&U256::from(offset + word * 32)).cloned())
+        .map(|word| state.symbolic_memory.get(&U256::from(offset + word * 32)).cloned())
         .collect::<Option<Vec<_>>>();
     if let Some(words) = words {
         *preimage = Some(words);
+    }
+}
+
+fn resolve_keccak(expr: &mut Expr, state: &PostprocessorState) {
+    let original = expr.clone();
+    let Expr::Keccak { preimage, .. } = expr else { return };
+    if let Some(known) = state.keccak_preimages.get(&original).and_then(|values| values.last()) {
+        *preimage = Some(known.clone());
+    } else {
+        capture_keccak(expr, state);
     }
 }
 
@@ -125,15 +135,28 @@ pub(crate) fn storage_inference_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    if let Statement::KeccakSnapshot(hash) = statement {
+        let original = hash.clone();
+        capture_keccak(hash, state);
+        if let Expr::Keccak { preimage: Some(preimage), .. } = hash {
+            state.keccak_preimages.entry(original).or_default().push(preimage.clone());
+        }
+        *statement = Statement::Noop;
+        return Ok(())
+    }
+
     if matches!(statement, Statement::CloseBlock) {
         if let Some(parent) = state.symbolic_memory_scopes.pop() {
             state.symbolic_memory = parent;
+        }
+        if let Some(parent) = state.keccak_preimage_scopes.pop() {
+            state.keccak_preimages = parent;
         }
         return Ok(())
     }
 
     statement.visit_exprs_mut(&mut |expr| {
-        resolve_keccak(expr, &state.symbolic_memory);
+        resolve_keccak(expr, state);
         if let Expr::StorageAccess(path) = expr {
             if let StoragePath::Slot { slot } = &**path {
                 *path = Box::new(path_from_slot(*slot.clone()));
@@ -146,6 +169,7 @@ pub(crate) fn storage_inference_postprocessor(
 
     if matches!(statement, Statement::If { .. } | Statement::IfRevertElse { .. }) {
         state.symbolic_memory_scopes.push(state.symbolic_memory.clone());
+        state.keccak_preimage_scopes.push(state.keccak_preimages.clone());
     }
 
     if let Statement::Assign { target: Expr::Index { base, index }, value } = statement {
@@ -169,6 +193,38 @@ mod tests {
             target: Expr::index("memory", Expr::Literal(U256::from(offset))),
             value,
         }
+    }
+
+    fn two_word_hash() -> Expr {
+        Expr::Keccak {
+            offset: Box::new(Expr::Literal(U256::ZERO)),
+            size: Box::new(Expr::Literal(U256::from(64))),
+            preimage: None,
+        }
+    }
+
+    #[test]
+    fn snapshots_reused_memory_for_nested_mapping() {
+        let mut state = PostprocessorState::default();
+        for mut statement in [
+            memory_write(0, Expr::identifier("owner")),
+            memory_write(32, Expr::Literal(U256::from(5))),
+            Statement::KeccakSnapshot(two_word_hash()),
+            memory_write(0, Expr::identifier("spender")),
+            memory_write(32, two_word_hash()),
+            Statement::KeccakSnapshot(two_word_hash()),
+        ] {
+            storage_inference_postprocessor(&mut statement, &mut state).unwrap();
+        }
+
+        let mut access = Statement::Return(Expr::StorageAccess(Box::new(StoragePath::Slot {
+            slot: Box::new(two_word_hash()),
+        })));
+        storage_inference_postprocessor(&mut access, &mut state).unwrap();
+        assert_eq!(
+            access.render(RenderTarget::Solidity),
+            "return storage[keccak256(spender, keccak256(owner, 0x05))];"
+        );
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::{ir::Statement, postprocess::PostprocessorState},
+    core::{
+        ir::{Expr, Statement},
+        postprocess::PostprocessorState,
+    },
     Error,
 };
 
@@ -17,7 +20,12 @@ pub(crate) fn variable_postprocessor(
 
     statement.visit_exprs_mut(&mut |expr| {
         let replacement = state.variable_map.iter().find_map(|(variable, value)| {
-            (value == expr && assignment_target.as_ref() != Some(variable)).then_some(variable)
+            let is_trivial = matches!(
+                value,
+                Expr::Identifier(_) | Expr::Literal(_) | Expr::Bool(_) | Expr::StringLiteral(_)
+            );
+            (!is_trivial && value == expr && assignment_target.as_ref() != Some(variable))
+                .then_some(variable)
         });
         if let Some(variable) = replacement {
             *expr = variable.clone();
@@ -32,7 +40,7 @@ mod tests {
     use alloy::primitives::U256;
 
     use super::*;
-    use crate::core::ir::{BinaryOp, Expr, RenderTarget};
+    use crate::core::ir::{BinaryOp, RenderTarget};
 
     #[test]
     fn replaces_matching_expression_subtree() {


### PR DESCRIPTION
## What changed? Why?

Stacked on #715.

Adds an IR-native storage-layout inference pipeline. The decompiler now recovers the memory preimages used by `SHA3`, classifies storage expressions semantically, and assigns consistent names and types from those paths instead of treating every `storage[keccak256(...)]` access as an unrelated generic mapping.

### Storage paths

Adds structured representations for:
- direct slots
- mappings and nested mappings
- dynamic arrays
- fields within mapping/array values
- packed fields with bit offsets and widths

### Keccak preimage recovery

`SHA3` expressions now retain their offset and size. A pre-storage pass tracks constant-offset memory writes and resolves canonical preimages such as:

```text
mstore(0x00, key)
mstore(0x20, slot)
sha3(0x00, 0x40)
```

into a mapping path rooted at `slot` with `key` as the mapping key.

Symbolic memory is scoped around conditional blocks so branch-local writes do not leak into later storage classifications.

### Naming and type inference

- accesses with the same root/layout reuse the same generated storage variable across different keys
- nested mappings generate nested mapping declarations
- dynamic array paths generate array declarations
- packed masks/shifts become packed paths with inferred widths
- common semantic expressions such as `msg.sender` and `address(...)` contribute address type evidence
- trivial memory aliases are no longer substituted back into recovered storage keys
- getter detection now consumes semantic storage expressions

Examples:

```solidity
storage[keccak256(msg.sender, 0x05)]
// becomes
storage_map_a[msg.sender]
```

```solidity
mapping(address => mapping(address => uint256)) storage_map_a;
```

## Notes to reviewers

This PR intentionally uses exact, constant-offset memory writes for preimage recovery. Unknown offsets, partial words, non-word-aligned hashes, and hashes larger than 512 bytes remain conservative rather than being guessed.

Key files:
- `crates/decompile/src/core/ir.rs`
- `crates/decompile/src/utils/postprocessors/storage_inference.rs`
- `crates/decompile/src/utils/postprocessors/storage.rs`
- `crates/decompile/src/core/postprocess.rs`

Stack order:
1. #715 — structured decompiler IR
2. this PR — semantic storage inference

## How has it been tested?

- `cargo test -p heimdall-decompiler`
- `cargo clippy -p heimdall-decompiler --all-targets -- -D warnings`
- `cargo test --workspace --lib`

Added tests covering:
- mapping preimage recovery
- dynamic arrays
- packed fields
- nested mapping declarations
- stable mapping names across different keys
- branch-local symbolic memory
- full postprocessing pipeline recovery
