### PR TITLE
feat(decompile): add type-aware IR simplification

### DIFF
--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -8,9 +8,9 @@ use crate::{
     interfaces::AnalyzedFunction,
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, eliminate_dead_variables,
-        memory_postprocessor, storage_inference_postprocessor, storage_postprocessor,
-        transient_postprocessor, type_cleanup_postprocessor, variable_postprocessor,
-        IrFunctionPostprocessor, IrPostprocessor,
+        inline_single_use_variables, memory_postprocessor, storage_inference_postprocessor,
+        storage_postprocessor, transient_postprocessor, type_cleanup_postprocessor,
+        variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
     },
     Error,
 };
@@ -138,6 +138,7 @@ impl PostprocessOrchestrator {
                 self.ir_passes.push(variable_postprocessor);
                 self.ir_passes.push(type_cleanup_postprocessor);
 
+                self.ir_function_passes.push(inline_single_use_variables);
                 self.ir_function_passes.push(eliminate_dead_variables);
             }
             AnalyzerType::Yul => {}

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -9,7 +9,8 @@ use crate::{
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, eliminate_dead_variables,
         memory_postprocessor, storage_inference_postprocessor, storage_postprocessor,
-        transient_postprocessor, variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
+        transient_postprocessor, type_cleanup_postprocessor, variable_postprocessor,
+        IrFunctionPostprocessor, IrPostprocessor,
     },
     Error,
 };
@@ -135,6 +136,7 @@ impl PostprocessOrchestrator {
                 self.ir_passes.push(storage_postprocessor);
                 self.ir_passes.push(transient_postprocessor);
                 self.ir_passes.push(variable_postprocessor);
+                self.ir_passes.push(type_cleanup_postprocessor);
 
                 self.ir_function_passes.push(eliminate_dead_variables);
             }

--- a/crates/decompile/src/utils/postprocessors/inline.rs
+++ b/crates/decompile/src/utils/postprocessors/inline.rs
@@ -1,0 +1,156 @@
+use std::collections::HashSet;
+
+use crate::{
+    core::{
+        ir::{Expr, Statement},
+        postprocess::PostprocessorState,
+    },
+    interfaces::AnalyzedFunction,
+    Error,
+};
+
+fn assignment(statement: &Statement) -> Option<(&str, &Expr)> {
+    match statement {
+        Statement::Assign { target: Expr::Identifier(name), value } |
+        Statement::DeclareAssign { target: Expr::Identifier(name), value, .. }
+            if name.starts_with("var_") =>
+        {
+            Some((name, value))
+        }
+        _ => None,
+    }
+}
+
+fn is_pure_inline_candidate(expr: &Expr) -> bool {
+    match expr {
+        Expr::Empty |
+        Expr::Identifier(_) |
+        Expr::Literal(_) |
+        Expr::Bool(_) |
+        Expr::StringLiteral(_) => true,
+        Expr::Unary { value, .. } | Expr::Cast { value, .. } => is_pure_inline_candidate(value),
+        Expr::Binary { lhs, rhs, .. } => {
+            is_pure_inline_candidate(lhs) && is_pure_inline_candidate(rhs)
+        }
+        Expr::Member { base, .. } => is_pure_inline_candidate(base),
+        Expr::Raw(_) |
+        Expr::Index { .. } |
+        Expr::Slice { .. } |
+        Expr::Keccak { .. } |
+        Expr::StorageAccess(_) |
+        Expr::Call { .. } => false,
+    }
+}
+
+fn usage_count(statement: &Statement, variable: &str) -> usize {
+    let mut count: usize = 0;
+    let mut statement = statement.clone();
+    statement.visit_exprs_mut(&mut |expr| {
+        if matches!(expr, Expr::Identifier(name) if name == variable) {
+            count += 1;
+        }
+    });
+
+    if matches!(
+        statement,
+        Statement::Assign { target: Expr::Identifier(ref name), .. } |
+        Statement::DeclareAssign { target: Expr::Identifier(ref name), .. }
+            if name == variable
+    ) {
+        count = count.saturating_sub(1);
+    }
+    count
+}
+
+/// Inlines pure local values used exactly once before their next assignment.
+pub(crate) fn inline_single_use_variables(
+    function: &mut AnalyzedFunction,
+    _: &mut PostprocessorState,
+) -> Result<(), Error> {
+    for assignment_idx in 0..function.statements.len() {
+        let Some((variable, value)) = assignment(&function.statements[assignment_idx]) else {
+            continue
+        };
+        let variable = variable.to_string();
+        let value = value.clone();
+        if !is_pure_inline_candidate(&value) {
+            continue
+        }
+        let mut identifiers = HashSet::new();
+        value.collect_identifiers(&mut identifiers);
+        if identifiers.contains(&variable) {
+            continue
+        }
+
+        let end = (assignment_idx + 1..function.statements.len())
+            .find(|&idx| {
+                assignment(&function.statements[idx]).is_some_and(|(name, _)| name == variable)
+            })
+            .unwrap_or(function.statements.len());
+        let uses = function.statements[assignment_idx + 1..end]
+            .iter()
+            .map(|statement| usage_count(statement, &variable))
+            .sum::<usize>();
+        if uses != 1 {
+            continue
+        }
+
+        for statement in &mut function.statements[assignment_idx + 1..end] {
+            statement.visit_exprs_mut(&mut |expr| {
+                if matches!(expr, Expr::Identifier(name) if name == &variable) {
+                    *expr = value.clone();
+                }
+            });
+        }
+        function.statements[assignment_idx] = Statement::Noop;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+
+    use super::*;
+    use crate::core::ir::{RenderTarget, Statement};
+
+    #[test]
+    fn inlines_single_use_cast() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::DeclareAssign {
+                ty: "address".to_string(),
+                target: Expr::identifier("var_a"),
+                value: Expr::Cast {
+                    ty: "address".to_string(),
+                    value: Box::new(Expr::identifier("arg0")),
+                },
+            },
+            Statement::Return(Expr::index("storage_map_a", Expr::identifier("var_a"))),
+        ];
+        inline_single_use_variables(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(matches!(function.statements[0], Statement::Noop));
+        assert_eq!(
+            function.statements[1].render(RenderTarget::Solidity),
+            "return storage_map_a[address(arg0)];"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_multiple_uses() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::Assign {
+                target: Expr::identifier("var_a"),
+                value: Expr::Literal(U256::from(1)),
+            },
+            Statement::Return(Expr::binary(
+                crate::core::ir::BinaryOp::Add,
+                Expr::identifier("var_a"),
+                Expr::identifier("var_a"),
+            )),
+        ];
+        inline_single_use_variables(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(!matches!(function.statements[0], Statement::Noop));
+    }
+}

--- a/crates/decompile/src/utils/postprocessors/inline.rs
+++ b/crates/decompile/src/utils/postprocessors/inline.rs
@@ -21,6 +21,10 @@ fn assignment(statement: &Statement) -> Option<(&str, &Expr)> {
     }
 }
 
+fn is_trivial_alias(expr: &Expr) -> bool {
+    matches!(expr, Expr::Identifier(_) | Expr::Literal(_) | Expr::Bool(_) | Expr::StringLiteral(_))
+}
+
 fn is_pure_inline_candidate(expr: &Expr) -> bool {
     match expr {
         Expr::Empty |
@@ -91,7 +95,7 @@ pub(crate) fn inline_single_use_variables(
             .iter()
             .map(|statement| usage_count(statement, &variable))
             .sum::<usize>();
-        if uses != 1 {
+        if uses == 0 || (uses != 1 && !is_trivial_alias(&value)) {
             continue
         }
 
@@ -142,7 +146,11 @@ mod tests {
         function.statements = vec![
             Statement::Assign {
                 target: Expr::identifier("var_a"),
-                value: Expr::Literal(U256::from(1)),
+                value: Expr::binary(
+                    crate::core::ir::BinaryOp::Add,
+                    Expr::identifier("arg0"),
+                    Expr::Literal(U256::from(1)),
+                ),
             },
             Statement::Return(Expr::binary(
                 crate::core::ir::BinaryOp::Add,

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -12,6 +12,7 @@ mod memory;
 mod storage;
 mod storage_inference;
 mod transient;
+mod types;
 mod variable;
 
 // re-export postprocessors
@@ -22,6 +23,7 @@ pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
 pub(crate) use storage_inference::storage_inference_postprocessor;
 pub(crate) use transient::transient_postprocessor;
+pub(crate) use types::type_cleanup_postprocessor;
 pub(crate) use variable::variable_postprocessor;
 
 /// A structured IR postprocessor function signature.

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 mod arithmetic;
 mod bitwise;
 mod deadcode;
+mod inline;
 mod memory;
 mod storage;
 mod storage_inference;
@@ -19,6 +20,7 @@ mod variable;
 pub(crate) use arithmetic::arithmetic_postprocessor;
 pub(crate) use bitwise::bitwise_mask_postprocessor;
 pub(crate) use deadcode::eliminate_dead_variables;
+pub(crate) use inline::inline_single_use_variables;
 pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
 pub(crate) use storage_inference::storage_inference_postprocessor;

--- a/crates/decompile/src/utils/postprocessors/types.rs
+++ b/crates/decompile/src/utils/postprocessors/types.rs
@@ -95,12 +95,21 @@ pub(crate) fn type_cleanup_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
-    statement.visit_exprs_mut(&mut |expr| {
-        let Expr::Cast { ty, value } = expr else { return };
-        let target = InferredType::parse(ty);
-        if target != InferredType::Unknown && infer_type(value, state) == target {
-            *expr = *value.clone();
+    statement.visit_exprs_mut(&mut |expr| match expr {
+        Expr::Cast { ty, value } => {
+            let target = InferredType::parse(ty);
+            if target != InferredType::Unknown && infer_type(value, state) == target {
+                *expr = *value.clone();
+            }
         }
+        Expr::Call { callee, args }
+            if callee == "address" &&
+                args.len() == 1 &&
+                infer_type(&args[0], state) == InferredType::Address =>
+        {
+            *expr = args.remove(0);
+        }
+        _ => {}
     });
     Ok(())
 }
@@ -123,6 +132,16 @@ mod tests {
         state.memory_type_map.insert("arg0".to_string(), "address".to_string());
         type_cleanup_postprocessor(&mut statement, &mut state).unwrap();
         assert_eq!(statement.render(RenderTarget::Solidity), "return arg0;");
+    }
+
+    #[test]
+    fn removes_redundant_address_conversion() {
+        let mut statement = Statement::Return(Expr::Call {
+            callee: "address".to_string(),
+            args: vec![Expr::identifier("msg.sender")],
+        });
+        type_cleanup_postprocessor(&mut statement, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(statement.render(RenderTarget::Solidity), "return msg.sender;");
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/types.rs
+++ b/crates/decompile/src/utils/postprocessors/types.rs
@@ -1,0 +1,139 @@
+use crate::{
+    core::{
+        ir::{BinaryOp, Expr, Statement, UnaryOp},
+        postprocess::PostprocessorState,
+    },
+    Error,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum InferredType {
+    Address,
+    Bool,
+    Uint(u16),
+    Int(u16),
+    Bytes(u16),
+    DynamicBytes,
+    String,
+    Unknown,
+}
+
+impl InferredType {
+    fn parse(ty: &str) -> Self {
+        let ty = ty.trim().trim_end_matches(" memory");
+        match ty {
+            "address" => Self::Address,
+            "bool" => Self::Bool,
+            "bytes" => Self::DynamicBytes,
+            "string" => Self::String,
+            _ if ty.starts_with("uint") => Self::Uint(ty[4..].parse().unwrap_or(256)),
+            _ if ty.starts_with("int") => Self::Int(ty[3..].parse().unwrap_or(256)),
+            _ if ty.starts_with("bytes") => Self::Bytes(ty[5..].parse::<u16>().unwrap_or(32) * 8),
+            _ => Self::Unknown,
+        }
+    }
+}
+
+fn mapping_value_type(ty: &str) -> Option<InferredType> {
+    if !ty.starts_with("mapping(") {
+        return None;
+    }
+    let value = ty.rsplit_once("=>")?.1.trim().trim_end_matches(')').trim();
+    Some(InferredType::parse(value))
+}
+
+fn infer_type(expr: &Expr, state: &PostprocessorState) -> InferredType {
+    match expr {
+        Expr::Identifier(name) => match name.as_str() {
+            "msg.sender" | "tx.origin" | "address(this)" => InferredType::Address,
+            "msg.value" | "block.timestamp" | "block.number" | "block.chainid" => {
+                InferredType::Uint(256)
+            }
+            _ => state
+                .memory_type_map
+                .get(name)
+                .or_else(|| state.storage_type_map.get(name))
+                .map(|ty| InferredType::parse(ty))
+                .unwrap_or(InferredType::Unknown),
+        },
+        Expr::Literal(_) => InferredType::Uint(256),
+        Expr::Bool(_) => InferredType::Bool,
+        Expr::StringLiteral(_) => InferredType::String,
+        Expr::Cast { ty, .. } => InferredType::parse(ty),
+        Expr::Unary { op: UnaryOp::LogicalNot, .. } => InferredType::Bool,
+        Expr::Unary { .. } => InferredType::Uint(256),
+        Expr::Binary { op, .. } => match op {
+            BinaryOp::Lt |
+            BinaryOp::Le |
+            BinaryOp::Gt |
+            BinaryOp::Ge |
+            BinaryOp::Eq |
+            BinaryOp::Ne => InferredType::Bool,
+            _ => InferredType::Uint(256),
+        },
+        Expr::Call { callee, .. } if callee == "address" => InferredType::Address,
+        Expr::Call { callee, .. } if callee == "keccak256" => InferredType::Bytes(256),
+        Expr::Keccak { .. } => InferredType::Bytes(256),
+        Expr::Index { base, .. } => match &**base {
+            Expr::Identifier(name) => state
+                .storage_type_map
+                .get(name)
+                .and_then(|ty| mapping_value_type(ty))
+                .unwrap_or(InferredType::Unknown),
+            _ => InferredType::Unknown,
+        },
+        Expr::Member { base, member } if member == "balance" => {
+            let _ = base;
+            InferredType::Uint(256)
+        }
+        _ => InferredType::Unknown,
+    }
+}
+
+/// Removes casts proven redundant by ABI, builtin, local-variable, or storage type information.
+pub(crate) fn type_cleanup_postprocessor(
+    statement: &mut Statement,
+    state: &mut PostprocessorState,
+) -> Result<(), Error> {
+    statement.visit_exprs_mut(&mut |expr| {
+        let Expr::Cast { ty, value } = expr else { return };
+        let target = InferredType::parse(ty);
+        if target != InferredType::Unknown && infer_type(value, state) == target {
+            *expr = *value.clone();
+        }
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ir::RenderTarget;
+
+    #[test]
+    fn removes_redundant_address_casts() {
+        let mut statement = Statement::Return(Expr::Cast {
+            ty: "address".to_string(),
+            value: Box::new(Expr::Cast {
+                ty: "address".to_string(),
+                value: Box::new(Expr::identifier("arg0")),
+            }),
+        });
+        let mut state = PostprocessorState::default();
+        state.memory_type_map.insert("arg0".to_string(), "address".to_string());
+        type_cleanup_postprocessor(&mut statement, &mut state).unwrap();
+        assert_eq!(statement.render(RenderTarget::Solidity), "return arg0;");
+    }
+
+    #[test]
+    fn keeps_narrowing_cast() {
+        let mut statement = Statement::Return(Expr::Cast {
+            ty: "uint8".to_string(),
+            value: Box::new(Expr::identifier("arg0")),
+        });
+        let mut state = PostprocessorState::default();
+        state.memory_type_map.insert("arg0".to_string(), "uint256".to_string());
+        type_cleanup_postprocessor(&mut statement, &mut state).unwrap();
+        assert_eq!(statement.render(RenderTarget::Solidity), "return uint8(arg0);");
+    }
+}

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -18,19 +18,28 @@ pub(crate) fn variable_postprocessor(
         _ => None,
     };
 
-    statement.visit_exprs_mut(&mut |expr| {
-        let replacement = state.variable_map.iter().find_map(|(variable, value)| {
-            let is_trivial = matches!(
-                value,
-                Expr::Identifier(_) | Expr::Literal(_) | Expr::Bool(_) | Expr::StringLiteral(_)
-            );
-            (!is_trivial && value == expr && assignment_target.as_ref() != Some(variable))
-                .then_some(variable)
+    // Keep branch and require conditions expressed in terms of their original operands. Replacing
+    // a comparison subtree with a VM temporary can later alias that temporary to one operand,
+    // turning checks such as `amount + total >= total` into `total >= total`.
+    let preserves_operands = matches!(
+        statement,
+        Statement::If { .. } | Statement::IfRevertElse { .. } | Statement::Require { .. }
+    );
+    if !preserves_operands {
+        statement.visit_exprs_mut(&mut |expr| {
+            let replacement = state.variable_map.iter().find_map(|(variable, value)| {
+                let is_trivial = matches!(
+                    value,
+                    Expr::Identifier(_) | Expr::Literal(_) | Expr::Bool(_) | Expr::StringLiteral(_)
+                );
+                (!is_trivial && value == expr && assignment_target.as_ref() != Some(variable))
+                    .then_some(variable)
+            });
+            if let Some(variable) = replacement {
+                *expr = variable.clone();
+            }
         });
-        if let Some(variable) = replacement {
-            *expr = variable.clone();
-        }
-    });
+    }
 
     Ok(())
 }
@@ -41,6 +50,26 @@ mod tests {
 
     use super::*;
     use crate::core::ir::{BinaryOp, RenderTarget};
+
+    #[test]
+    fn preserves_original_condition_operands() {
+        let sum = Expr::Binary {
+            op: BinaryOp::Add,
+            lhs: Box::new(Expr::identifier("amount")),
+            rhs: Box::new(Expr::identifier("total")),
+        };
+        let mut statement = Statement::If {
+            condition: Expr::Binary {
+                op: BinaryOp::Ge,
+                lhs: Box::new(sum.clone()),
+                rhs: Box::new(Expr::identifier("total")),
+            },
+        };
+        let mut state = PostprocessorState::default();
+        state.variable_map.insert(Expr::identifier("var_a"), sum);
+        variable_postprocessor(&mut statement, &mut state).unwrap();
+        assert_eq!(statement.render(RenderTarget::Solidity), "if (amount + total >= total) {");
+    }
 
     #[test]
     fn replaces_matching_expression_subtree() {


### PR DESCRIPTION
## What changed? Why?

Stacked on #716.

Uses ABI and semantic IR type evidence to remove redundant casts, then propagates pure local values to reduce temporary-variable noise in decompiler output.

### Type-aware cleanup

Adds an IR type environment that understands:
- ABI-derived argument and memory-variable types
- generated storage declarations
- addresses such as `msg.sender`, `tx.origin`, and `address(this)`
- booleans and comparisons
- integer arithmetic
- fixed bytes and Keccak results
- mapping value types

It removes only casts/conversions whose input is already proven to have the target type. Narrowing casts are retained.

Examples:

```solidity
address(address(address(arg0))) -> arg0
address(address(msg.sender))    -> msg.sender
address(address(this)).balance  -> address(this).balance
```

### Copy propagation

Adds a function-wide IR pass that:
- inlines pure expressions used exactly once
- always propagates trivial aliases such as identifiers and literals
- does not inline storage reads, calls, Keccak operations, slices, or other potentially unsafe expressions
- leaves multiply-used nontrivial expressions assigned to avoid code expansion
- removes the replaced assignments through the existing IR dead-code pass

### WETH9 comparison

Using `crates/vm/benches/testdata/weth9.hex`, output drops from 390 lines on #716 to 375 lines.

Notable improvements:

```solidity
return storage_map_f[address(arg0)][var_b];
```

becomes:

```solidity
return storage_map_f[arg0][arg1];
```

```solidity
storage_map_f[address(address(msg.sender))][var_a] = arg1;
```

becomes:

```solidity
storage_map_f[msg.sender][arg0] = arg1;
```

and:

```solidity
address var_a = address(address(this)).balance;
return var_a;
```

becomes:

```solidity
return address(this).balance;
```

An attempted memory-write versioning pass was intentionally excluded: flattened symbolic traces do not yet provide sufficient dominance information to version read-before-write memory references safely. That should follow structured control-flow recovery rather than being guessed here.

## Notes to reviewers

Key files:
- `crates/decompile/src/utils/postprocessors/types.rs`
- `crates/decompile/src/utils/postprocessors/inline.rs`
- `crates/decompile/src/core/postprocess.rs`

Stack order:
1. #715 — structured decompiler IR
2. #716 — semantic storage inference
3. this PR — type-aware cleanup and copy propagation

## How has it been tested?

- `cargo test -p heimdall-decompiler`
- `cargo clippy -p heimdall-decompiler --all-targets -- -D warnings`
- `cargo test --workspace --lib`
- compared WETH9 decompiler output against #716

Added tests for:
- redundant nested address casts
- redundant `address(...)` conversions
- preserving narrowing casts
- single-use pure expression inlining
- trivial alias propagation
- avoiding expansion of multiply-used nontrivial expressions
