### PR TITLE
feat(decompile): prune statically infeasible branches

### DIFF
--- a/crates/decompile/src/core/analyze.rs
+++ b/crates/decompile/src/core/analyze.rs
@@ -5,7 +5,10 @@ use heimdall_vm::ext::exec::VMTrace;
 use tracing::debug;
 
 use crate::{
-    core::ir::{Expr, Statement},
+    core::{
+        control_flow::prune_constant_branches,
+        ir::{Expr, Statement},
+    },
     interfaces::AnalyzedFunction,
     utils::heuristics::{
         argument_heuristic, event_heuristic, extcall_heuristic, modifier_heuristic,
@@ -110,13 +113,25 @@ impl Analyzer {
     }
 
     /// Performs analysis
-    pub(crate) async fn analyze(&mut self, trace_root: VMTrace) -> Result<AnalyzedFunction, Error> {
+    pub(crate) async fn analyze(
+        &mut self,
+        mut trace_root: VMTrace,
+    ) -> Result<AnalyzedFunction, Error> {
         debug!(
             "analzying symbolic execution trace for '{}' with the {} analyzer",
             self.function.selector, self.typ
         );
         self.function.analyzer_type = self.typ;
         let start_analysis_time = Instant::now();
+
+        // Remove paths made infeasible by identities such as `x == x` before flattening the trace.
+        let pruned = prune_constant_branches(&mut trace_root);
+        if pruned.paths > 0 {
+            debug!(
+                "pruned {} infeasible paths across {} constant branches for '{}'",
+                pruned.paths, pruned.branches, self.function.selector
+            );
+        }
 
         // Register heuristics
         self.register_heuristics()?;

--- a/crates/decompile/src/core/control_flow.rs
+++ b/crates/decompile/src/core/control_flow.rs
@@ -76,16 +76,14 @@ pub(crate) fn prune_constant_branches(trace: &mut VMTrace) -> PruneStats {
                 // child when it is the only path exposing a RETURN; concrete placeholder values
                 // can otherwise make a live return look constant during symbolic execution.
                 let drops_unique_return = expected.is_some_and(|expected| {
-                    let feasible_has_return = trace
-                        .children
-                        .iter()
-                        .filter(|child| child.instruction == expected)
-                        .any(|child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN));
-                    let discarded_has_return = trace
-                        .children
-                        .iter()
-                        .filter(|child| child.instruction != expected)
-                        .any(|child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN));
+                    let feasible_has_return =
+                        trace.children.iter().filter(|child| child.instruction == expected).any(
+                            |child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN),
+                        );
+                    let discarded_has_return =
+                        trace.children.iter().filter(|child| child.instruction != expected).any(
+                            |child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN),
+                        );
                     discarded_has_return && !feasible_has_return
                 });
 

--- a/crates/decompile/src/core/control_flow.rs
+++ b/crates/decompile/src/core/control_flow.rs
@@ -33,6 +33,11 @@ fn is_complete(trace: &VMTrace) -> bool {
     }
 }
 
+fn contains_opcode(trace: &VMTrace, opcode: u8) -> bool {
+    trace.operations.iter().any(|state| state.last_instruction.opcode == opcode) ||
+        trace.children.iter().any(|child| contains_opcode(child, opcode))
+}
+
 /// Remove the infeasible child of each JUMPI whose condition is provably constant.
 ///
 /// Symbolic execution intentionally explores both children. This pass uses expression identity and
@@ -67,8 +72,26 @@ pub(crate) fn prune_constant_branches(trace: &mut VMTrace) -> PruneStats {
                         .peekable();
                     feasible.peek().is_some() && feasible.all(is_complete)
                 });
+                // Return paths also determine the recovered ABI. Preserve a nominally infeasible
+                // child when it is the only path exposing a RETURN; concrete placeholder values
+                // can otherwise make a live return look constant during symbolic execution.
+                let drops_unique_return = expected.is_some_and(|expected| {
+                    let feasible_has_return = trace
+                        .children
+                        .iter()
+                        .filter(|child| child.instruction == expected)
+                        .any(|child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN));
+                    let discarded_has_return = trace
+                        .children
+                        .iter()
+                        .filter(|child| child.instruction != expected)
+                        .any(|child| contains_opcode(child, heimdall_vm::core::opcodes::RETURN));
+                    discarded_has_return && !feasible_has_return
+                });
 
-                if let (Some(expected), true) = (expected, feasible_is_complete) {
+                if let (Some(expected), true, false) =
+                    (expected, feasible_is_complete, drops_unique_return)
+                {
                     let old_len = trace.children.len();
                     trace.children.retain(|child| child.instruction == expected);
                     let removed = old_len.saturating_sub(trace.children.len());
@@ -168,6 +191,16 @@ mod tests {
         // children relies on its sibling for the rest of the function body.
         let condition = WrappedOpcode::new(opcodes::EQ, vec![caller(), caller()]);
         let mut trace = trace_with_condition(condition, leaf(21, opcodes::JUMPI));
+        let stats = prune_constant_branches(&mut trace);
+        assert_eq!(stats, PruneStats::default());
+        assert_eq!(trace.children.len(), 2);
+    }
+
+    #[test]
+    fn keeps_unique_return_path_for_abi_recovery() {
+        let condition = WrappedOpcode::new(opcodes::EQ, vec![caller(), caller()]);
+        let mut trace = trace_with_condition(condition, leaf(21, opcodes::REVERT));
+        trace.children[0] = leaf(11, opcodes::RETURN);
         let stats = prune_constant_branches(&mut trace);
         assert_eq!(stats, PruneStats::default());
         assert_eq!(trace.children.len(), 2);

--- a/crates/decompile/src/core/control_flow.rs
+++ b/crates/decompile/src/core/control_flow.rs
@@ -1,0 +1,136 @@
+use heimdall_vm::ext::exec::VMTrace;
+
+use super::ir::Expr;
+
+/// Result of pruning statically decidable branches from a symbolic execution trace.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PruneStats {
+    pub branches: usize,
+    pub paths: usize,
+}
+
+fn constant_truthiness(expr: Expr) -> Option<bool> {
+    match expr.simplify() {
+        Expr::Bool(value) => Some(value),
+        Expr::Literal(value) => Some(!value.is_zero()),
+        _ => None,
+    }
+}
+
+/// Remove the infeasible child of each JUMPI whose condition is provably constant.
+///
+/// Symbolic execution intentionally explores both children. This pass uses expression identity and
+/// local folding to recover cases such as `msg.sender == msg.sender` without treating concrete
+/// placeholder calldata values as constants.
+pub(crate) fn prune_constant_branches(trace: &mut VMTrace) -> PruneStats {
+    let mut stats = PruneStats::default();
+
+    if let Some(state) = trace.operations.last() {
+        let instruction = &state.last_instruction;
+        if instruction.opcode == 0x57 {
+            let truthiness = instruction
+                .input_operations
+                .get(1)
+                .map(Expr::from_opcode)
+                .and_then(constant_truthiness);
+            if let Some(taken) = truthiness {
+                let jump_destination = instruction
+                    .inputs
+                    .first()
+                    .and_then(|destination| u128::try_from(*destination).ok())
+                    .map(|destination| destination.saturating_add(1));
+                let fallthrough = instruction.instruction.saturating_add(1);
+                let expected = if taken { jump_destination } else { Some(fallthrough) };
+
+                if let Some(expected) = expected {
+                    let old_len = trace.children.len();
+                    trace.children.retain(|child| child.instruction == expected);
+                    let removed = old_len.saturating_sub(trace.children.len());
+                    if removed > 0 {
+                        stats.branches += 1;
+                        stats.paths += removed;
+                    }
+                }
+            }
+        }
+    }
+
+    for child in &mut trace.children {
+        let child_stats = prune_constant_branches(child);
+        stats.branches += child_stats.branches;
+        stats.paths += child_stats.paths;
+    }
+    stats
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy::primitives::U256;
+    use heimdall_vm::{
+        core::{
+            memory::Memory,
+            opcodes::{self, WrappedInput, WrappedOpcode},
+            stack::Stack,
+            storage::Storage,
+            vm::{Instruction, State},
+        },
+        ext::exec::VMTrace,
+    };
+
+    use super::*;
+
+    fn caller() -> WrappedInput {
+        WrappedInput::Opcode(Arc::new(WrappedOpcode::new(opcodes::CALLER, vec![])))
+    }
+
+    fn trace_with_condition(condition: WrappedOpcode) -> VMTrace {
+        VMTrace {
+            instruction: 1,
+            gas_used: 0,
+            operations: vec![State {
+                last_instruction: Instruction {
+                    instruction: 10,
+                    opcode: opcodes::JUMPI,
+                    inputs: vec![U256::from(20), U256::from(1)],
+                    outputs: vec![],
+                    input_operations: vec![
+                        WrappedOpcode::new(opcodes::PUSH1, vec![U256::from(20).into()]),
+                        condition,
+                    ],
+                    output_operations: vec![],
+                },
+                gas_used: 0,
+                gas_remaining: 0,
+                stack: Stack::new(),
+                memory: Memory::new(),
+                storage: Storage::new(),
+                events: vec![],
+            }],
+            children: vec![
+                VMTrace { instruction: 11, gas_used: 0, operations: vec![], children: vec![] },
+                VMTrace { instruction: 21, gas_used: 0, operations: vec![], children: vec![] },
+            ],
+        }
+    }
+
+    #[test]
+    fn keeps_only_taken_path_for_identical_equality() {
+        let condition = WrappedOpcode::new(opcodes::EQ, vec![caller(), caller()]);
+        let mut trace = trace_with_condition(condition);
+        let stats = prune_constant_branches(&mut trace);
+        assert_eq!(stats, PruneStats { branches: 1, paths: 1 });
+        assert_eq!(trace.children.len(), 1);
+        assert_eq!(trace.children[0].instruction, 21);
+    }
+
+    #[test]
+    fn keeps_both_paths_for_symbolic_condition() {
+        let condition = WrappedOpcode::new(opcodes::CALLDATALOAD, vec![U256::from(4).into()]);
+        let mut trace = trace_with_condition(condition);
+        let stats = prune_constant_branches(&mut trace);
+        assert_eq!(stats, PruneStats::default());
+        assert_eq!(trace.children.len(), 2);
+    }
+}

--- a/crates/decompile/src/core/control_flow.rs
+++ b/crates/decompile/src/core/control_flow.rs
@@ -1,4 +1,7 @@
-use heimdall_vm::ext::exec::VMTrace;
+use heimdall_vm::{
+    core::opcodes::{OpCodeInfo, JUMPI},
+    ext::exec::VMTrace,
+};
 
 use super::ir::Expr;
 
@@ -9,7 +12,8 @@ pub(crate) struct PruneStats {
     pub paths: usize,
 }
 
-fn constant_truthiness(expr: Expr) -> Option<bool> {
+/// Folds a branch condition to a constant when its truthiness is statically decidable.
+pub(crate) fn constant_truthiness(expr: Expr) -> Option<bool> {
     match expr.simplify() {
         Expr::Bool(value) => Some(value),
         Expr::Literal(value) => Some(!value.is_zero()),
@@ -17,17 +21,30 @@ fn constant_truthiness(expr: Expr) -> Option<bool> {
     }
 }
 
+/// Whether every path below this trace ends in a terminating instruction.
+///
+/// Symbolic execution deduplicates revisited jumps across sibling paths, so a subtree cut short at
+/// a JUMPI may rely on a sibling for the rest of its body. Such a subtree is not self-contained.
+fn is_complete(trace: &VMTrace) -> bool {
+    match trace.operations.last().map(|state| state.last_instruction.opcode) {
+        Some(JUMPI) => trace.children.len() == 2 && trace.children.iter().all(is_complete),
+        Some(opcode) => trace.children.is_empty() && OpCodeInfo::from(opcode).terminating(),
+        None => false,
+    }
+}
+
 /// Remove the infeasible child of each JUMPI whose condition is provably constant.
 ///
 /// Symbolic execution intentionally explores both children. This pass uses expression identity and
 /// local folding to recover cases such as `msg.sender == msg.sender` without treating concrete
-/// placeholder calldata values as constants.
+/// placeholder calldata values as constants. The infeasible child is only dropped when the feasible
+/// child is complete, since a truncated feasible child may share its continuation with the sibling.
 pub(crate) fn prune_constant_branches(trace: &mut VMTrace) -> PruneStats {
     let mut stats = PruneStats::default();
 
     if let Some(state) = trace.operations.last() {
         let instruction = &state.last_instruction;
-        if instruction.opcode == 0x57 {
+        if instruction.opcode == JUMPI {
             let truthiness = instruction
                 .input_operations
                 .get(1)
@@ -42,7 +59,16 @@ pub(crate) fn prune_constant_branches(trace: &mut VMTrace) -> PruneStats {
                 let fallthrough = instruction.instruction.saturating_add(1);
                 let expected = if taken { jump_destination } else { Some(fallthrough) };
 
-                if let Some(expected) = expected {
+                let feasible_is_complete = expected.is_some_and(|expected| {
+                    let mut feasible = trace
+                        .children
+                        .iter()
+                        .filter(|child| child.instruction == expected)
+                        .peekable();
+                    feasible.peek().is_some() && feasible.all(is_complete)
+                });
+
+                if let (Some(expected), true) = (expected, feasible_is_complete) {
                     let old_len = trace.children.len();
                     trace.children.retain(|child| child.instruction == expected);
                     let removed = old_len.saturating_sub(trace.children.len());
@@ -85,40 +111,51 @@ mod tests {
         WrappedInput::Opcode(Arc::new(WrappedOpcode::new(opcodes::CALLER, vec![])))
     }
 
-    fn trace_with_condition(condition: WrappedOpcode) -> VMTrace {
+    fn state(instruction: u128, opcode: u8, input_operations: Vec<WrappedOpcode>) -> State {
+        State {
+            last_instruction: Instruction {
+                instruction,
+                opcode,
+                inputs: vec![U256::from(20), U256::from(1)],
+                outputs: vec![],
+                input_operations,
+                output_operations: vec![],
+            },
+            gas_used: 0,
+            gas_remaining: 0,
+            stack: Stack::new(),
+            memory: Memory::new(),
+            storage: Storage::new(),
+            events: vec![],
+        }
+    }
+
+    fn leaf(instruction: u128, opcode: u8) -> VMTrace {
+        VMTrace {
+            instruction,
+            gas_used: 0,
+            operations: vec![state(instruction, opcode, vec![])],
+            children: vec![],
+        }
+    }
+
+    fn trace_with_condition(condition: WrappedOpcode, taken: VMTrace) -> VMTrace {
         VMTrace {
             instruction: 1,
             gas_used: 0,
-            operations: vec![State {
-                last_instruction: Instruction {
-                    instruction: 10,
-                    opcode: opcodes::JUMPI,
-                    inputs: vec![U256::from(20), U256::from(1)],
-                    outputs: vec![],
-                    input_operations: vec![
-                        WrappedOpcode::new(opcodes::PUSH1, vec![U256::from(20).into()]),
-                        condition,
-                    ],
-                    output_operations: vec![],
-                },
-                gas_used: 0,
-                gas_remaining: 0,
-                stack: Stack::new(),
-                memory: Memory::new(),
-                storage: Storage::new(),
-                events: vec![],
-            }],
-            children: vec![
-                VMTrace { instruction: 11, gas_used: 0, operations: vec![], children: vec![] },
-                VMTrace { instruction: 21, gas_used: 0, operations: vec![], children: vec![] },
-            ],
+            operations: vec![state(
+                10,
+                opcodes::JUMPI,
+                vec![WrappedOpcode::new(opcodes::PUSH1, vec![U256::from(20).into()]), condition],
+            )],
+            children: vec![leaf(11, opcodes::STOP), taken],
         }
     }
 
     #[test]
     fn keeps_only_taken_path_for_identical_equality() {
         let condition = WrappedOpcode::new(opcodes::EQ, vec![caller(), caller()]);
-        let mut trace = trace_with_condition(condition);
+        let mut trace = trace_with_condition(condition, leaf(21, opcodes::STOP));
         let stats = prune_constant_branches(&mut trace);
         assert_eq!(stats, PruneStats { branches: 1, paths: 1 });
         assert_eq!(trace.children.len(), 1);
@@ -126,9 +163,20 @@ mod tests {
     }
 
     #[test]
+    fn keeps_both_paths_when_taken_path_is_truncated() {
+        // The executor deduplicates revisited jumps, so a taken path that stops at a JUMPI without
+        // children relies on its sibling for the rest of the function body.
+        let condition = WrappedOpcode::new(opcodes::EQ, vec![caller(), caller()]);
+        let mut trace = trace_with_condition(condition, leaf(21, opcodes::JUMPI));
+        let stats = prune_constant_branches(&mut trace);
+        assert_eq!(stats, PruneStats::default());
+        assert_eq!(trace.children.len(), 2);
+    }
+
+    #[test]
     fn keeps_both_paths_for_symbolic_condition() {
         let condition = WrappedOpcode::new(opcodes::CALLDATALOAD, vec![U256::from(4).into()]);
-        let mut trace = trace_with_condition(condition);
+        let mut trace = trace_with_condition(condition, leaf(21, opcodes::STOP));
         let stats = prune_constant_branches(&mut trace);
         assert_eq!(stats, PruneStats::default());
         assert_eq!(trace.children.len(), 2);

--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -777,7 +777,27 @@ impl Statement {
 
     fn render_solidity(&self) -> String {
         match self {
-            Self::Assign { target, value } => format!("{} = {};", target.render(), value.render()),
+            Self::Assign { target, value } => {
+                if let Expr::Binary { op, lhs, rhs } = value {
+                    let compound = match op {
+                        BinaryOp::Add => Some("+="),
+                        BinaryOp::Sub => Some("-="),
+                        BinaryOp::Mul => Some("*="),
+                        BinaryOp::Div => Some("/="),
+                        BinaryOp::Mod => Some("%="),
+                        _ => None,
+                    };
+                    if let Some(compound) = compound {
+                        if &**lhs == target {
+                            return format!("{} {compound} {};", target.render(), rhs.render());
+                        }
+                        if matches!(op, BinaryOp::Add | BinaryOp::Mul) && &**rhs == target {
+                            return format!("{} {compound} {};", target.render(), lhs.render());
+                        }
+                    }
+                }
+                format!("{} = {};", target.render(), value.render())
+            }
             Self::DeclareAssign { ty, target, value } => {
                 format!("{ty} {} = {};", target.render(), value.render())
             }
@@ -857,6 +877,20 @@ mod tests {
             value: Expr::identifier("arg0"),
         };
         assert_eq!(statement.render(RenderTarget::Solidity), "storage[0x02] = arg0;");
+    }
+
+    #[test]
+    fn renders_compound_assignment() {
+        let target = Expr::index("balances", Expr::identifier("msg.sender"));
+        let statement = Statement::Assign {
+            target: target.clone(),
+            value: Expr::Binary {
+                op: BinaryOp::Sub,
+                lhs: Box::new(target),
+                rhs: Box::new(Expr::identifier("amount")),
+            },
+        };
+        assert_eq!(statement.render(RenderTarget::Solidity), "balances[msg.sender] -= amount;");
     }
 
     #[test]

--- a/crates/decompile/src/core/mod.rs
+++ b/crates/decompile/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod analyze;
+pub(crate) mod control_flow;
 pub(crate) mod ir;
 pub(crate) mod out;
 pub(crate) mod postprocess;

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -8,9 +8,10 @@ use crate::{
     interfaces::AnalyzedFunction,
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, eliminate_dead_variables,
-        inline_single_use_variables, memory_postprocessor, storage_inference_postprocessor,
-        storage_postprocessor, transient_postprocessor, type_cleanup_postprocessor,
-        variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
+        inline_single_use_variables, memory_postprocessor, normalize_typed_returns,
+        storage_inference_postprocessor, storage_postprocessor, transient_postprocessor,
+        type_cleanup_postprocessor, variable_postprocessor, IrFunctionPostprocessor,
+        IrPostprocessor,
     },
     Error,
 };
@@ -142,6 +143,7 @@ impl PostprocessOrchestrator {
                 self.ir_passes.push(variable_postprocessor);
                 self.ir_passes.push(type_cleanup_postprocessor);
 
+                self.ir_function_passes.push(normalize_typed_returns);
                 self.ir_function_passes.push(inline_single_use_variables);
                 self.ir_function_passes.push(eliminate_dead_variables);
             }

--- a/crates/decompile/src/utils/heuristics/solidity.rs
+++ b/crates/decompile/src/utils/heuristics/solidity.rs
@@ -114,6 +114,9 @@ pub(crate) fn solidity_heuristic<'a>(
             0x57 => {
                 // this is an if conditional for the children branches
                 let conditional_expr = Expr::from_opcode(&instruction.input_operations[1]);
+                if matches!(conditional_expr, Expr::Bool(_) | Expr::Literal(_)) {
+                    return Ok(())
+                }
                 let conditional = conditional_expr.render();
 
                 // perform a series of checks to determine if the condition

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
 pub(crate) use storage_inference::storage_inference_postprocessor;
 pub(crate) use transient::transient_postprocessor;
-pub(crate) use types::type_cleanup_postprocessor;
+pub(crate) use types::{normalize_typed_returns, type_cleanup_postprocessor};
 pub(crate) use variable::variable_postprocessor;
 
 /// A structured IR postprocessor function signature.

--- a/crates/decompile/src/utils/postprocessors/types.rs
+++ b/crates/decompile/src/utils/postprocessors/types.rs
@@ -3,6 +3,7 @@ use crate::{
         ir::{BinaryOp, Expr, Statement, UnaryOp},
         postprocess::PostprocessorState,
     },
+    interfaces::AnalyzedFunction,
     Error,
 };
 
@@ -114,10 +115,38 @@ pub(crate) fn type_cleanup_postprocessor(
     Ok(())
 }
 
+/// Rewrites literal return values using the function's inferred return type.
+pub(crate) fn normalize_typed_returns(
+    function: &mut AnalyzedFunction,
+    _: &mut PostprocessorState,
+) -> Result<(), Error> {
+    if function.returns.as_deref() != Some("bool") {
+        return Ok(())
+    }
+    for statement in &mut function.statements {
+        if let Statement::Return(Expr::Literal(value)) = statement {
+            if value.is_zero() || *value == alloy::primitives::U256::from(1) {
+                *statement = Statement::Return(Expr::Bool(!value.is_zero()));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::ir::RenderTarget;
+
+    #[test]
+    fn renders_boolean_return() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.returns = Some("bool".to_string());
+        function.statements =
+            vec![Statement::Return(Expr::Literal(alloy::primitives::U256::from(1)))];
+        normalize_typed_returns(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements[0].render(RenderTarget::Solidity), "return true;");
+    }
 
     #[test]
     fn removes_redundant_address_casts() {


### PR DESCRIPTION
## What changed? Why?

Stacked on #718.

Prunes symbolic-execution branches whose JUMPI conditions are provably constant from the IR expression tree. This prevents infeasible child traces from being flattened into generated source.

The symbolic executor deliberately explores both sides of every JUMPI. That is useful for coverage, but it previously retained branches such as `msg.sender != msg.sender` in WETH9's `transfer`, producing irrelevant allowance checks, duplicate balance updates, `if (true)` wrappers, and statements after returns.

### Branch feasibility

Before analysis, each `VMTrace` now:
- converts its terminating JUMPI condition to `Expr`
- applies local semantic simplification
- recognizes literal and boolean truth values
- retains only the taken child for `true`
- retains only the fallthrough child for `false`
- leaves symbolic conditions untouched
- recursively prunes child traces

This relies only on proven expression identities and constants; concrete placeholder calldata values are not treated as static evidence.

### Source cleanup

- constant branch wrappers are omitted
- self-referential assignments render as compound assignments
- literal `0`/`1` returns become `false`/`true` when the function return type is known to be `bool`

### WETH9 result

Before this PR, `transfer` contained impossible allowance paths and repeated transfer bodies. It now decompiles to:

```solidity
function Unresolved_a9059cbb(address arg0, uint256 arg1)
    public
    returns (bool)
{
    require(storage_map_c[msg.sender] >= arg1);
    storage_map_c[msg.sender] -= arg1;
    storage_map_c[arg0] += arg1;
    emit Event_ddf252ad(msg.sender, arg0, arg1);
    return true;
}
```

This matches WETH9's effective `transfer(msg.sender, dst, wad)` path.

Bundled WETH9 output drops from 373 lines on #718 to 357 lines.

## Notes to reviewers

Key files:
- `crates/decompile/src/core/control_flow.rs`: trace feasibility and pruning
- `crates/decompile/src/core/analyze.rs`: pruning integration before analysis
- `crates/decompile/src/core/ir.rs`: compound assignment rendering
- `crates/decompile/src/utils/postprocessors/types.rs`: typed boolean returns

This does not attempt to restructure genuinely symbolic alternatives yet. `transferFrom`, whose `src == msg.sender` condition depends on calldata, therefore remains multi-path and is a candidate for nested block/if-else reconstruction.

Stack order:
1. #715 — structured decompiler IR
2. #716 — semantic storage inference
3. #717 — type-aware cleanup
4. #718 — canonical storage roots
5. this PR — constant branch pruning

## How has it been tested?

- `cargo test -p heimdall-decompiler`
- `cargo clippy -p heimdall-decompiler --all-targets -- -D warnings`
- `cargo test --workspace --lib`
- compared bundled WETH9 output against #718

Added tests proving:
- identical symbolic expressions select only the feasible child
- genuinely symbolic conditions retain both children
- compound assignment rendering
- type-directed boolean return rendering
