### PR TITLE
feat(decompile): reconstruct structured branch bodies

### DIFF
--- a/crates/decompile/src/core/analyze.rs
+++ b/crates/decompile/src/core/analyze.rs
@@ -174,7 +174,53 @@ impl Analyzer {
                 }
             }
 
-            // recurse into the children of the current trace branch
+            // Preserve the taken and fallthrough children as explicit alternatives for Solidity.
+            if self.typ == AnalyzerType::Solidity {
+                if let Some(state) = branch.operations.last() {
+                    let instruction = &state.last_instruction;
+                    if instruction.opcode == 0x57 && !branch.children.is_empty() {
+                        if branch.children.len() == 1 {
+                            self.analyze_inner(&branch.children[0], analyzer_state).await?;
+                            return Ok(())
+                        }
+
+                        let destination = instruction
+                            .inputs
+                            .first()
+                            .and_then(|value| u128::try_from(*value).ok())
+                            .map(|value| value.saturating_add(1));
+                        let fallthrough = instruction.instruction.saturating_add(1);
+                        let taken = destination.and_then(|pc| {
+                            branch.children.iter().find(|child| child.instruction == pc)
+                        });
+                        let not_taken =
+                            branch.children.iter().find(|child| child.instruction == fallthrough);
+
+                        if let (Some(taken), Some(not_taken)) = (taken, not_taken) {
+                            let condition = instruction
+                                .input_operations
+                                .get(1)
+                                .map(Expr::from_opcode)
+                                .unwrap_or_else(|| Expr::identifier("unknown_condition"));
+                            self.function.push_statement(Statement::If { condition });
+                            let mut taken_state = analyzer_state.clone();
+                            self.analyze_inner(taken, &mut taken_state).await?;
+                            self.function.push_statement(Statement::Else);
+                            let mut fallthrough_state = analyzer_state.clone();
+                            self.analyze_inner(not_taken, &mut fallthrough_state).await?;
+                            self.function.push_statement(Statement::CloseBlock);
+                            return Ok(())
+                        }
+                    }
+                }
+
+                for child in &branch.children {
+                    self.analyze_inner(child, analyzer_state).await?;
+                }
+                return Ok(())
+            }
+
+            // Yul continues to use its flat control-flow markers.
             for child in &branch.children {
                 self.analyze_inner(child, analyzer_state).await?;
             }

--- a/crates/decompile/src/core/analyze.rs
+++ b/crates/decompile/src/core/analyze.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use crate::{
     core::{
-        control_flow::prune_constant_branches,
+        control_flow::{constant_truthiness, prune_constant_branches},
         ir::{Expr, Statement},
     },
     interfaces::AnalyzedFunction,
@@ -202,6 +202,21 @@ impl Analyzer {
                                 .get(1)
                                 .map(Expr::from_opcode)
                                 .unwrap_or_else(|| Expr::identifier("unknown_condition"));
+
+                            // A constant condition that survived pruning means the feasible
+                            // child was cut short by jump deduplication and its sibling holds
+                            // the rest of the body, so render both sequentially.
+                            if let Some(truthiness) = constant_truthiness(condition.clone()) {
+                                let (feasible, sibling) = if truthiness {
+                                    (taken, not_taken)
+                                } else {
+                                    (not_taken, taken)
+                                };
+                                self.analyze_inner(feasible, analyzer_state).await?;
+                                self.analyze_inner(sibling, analyzer_state).await?;
+                                return Ok(())
+                            }
+
                             self.function.push_statement(Statement::If { condition });
                             let mut taken_state = analyzer_state.clone();
                             self.analyze_inner(taken, &mut taken_state).await?;

--- a/crates/decompile/src/core/analyze.rs
+++ b/crates/decompile/src/core/analyze.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use crate::{
     core::{
-        control_flow::{constant_truthiness, prune_constant_branches},
+        control_flow::{constant_truthiness, is_bare_reverting, prune_constant_branches},
         ir::{Expr, Statement},
     },
     interfaces::AnalyzedFunction,
@@ -180,7 +180,25 @@ impl Analyzer {
                     let instruction = &state.last_instruction;
                     if instruction.opcode == 0x57 && !branch.children.is_empty() {
                         if branch.children.len() == 1 {
-                            self.analyze_inner(&branch.children[0], analyzer_state).await?;
+                            let condition = instruction
+                                .input_operations
+                                .get(1)
+                                .map(Expr::from_opcode)
+                                .unwrap_or_else(|| Expr::identifier("unknown_condition"));
+                            if constant_truthiness(condition.clone()).is_none() &&
+                                is_bare_reverting(&branch.children[0])
+                            {
+                                // The executor can deduplicate the successful sibling while
+                                // retaining only its revert path. Preserve the branch as a guard
+                                // instead of silently dropping its condition.
+                                self.function.push_statement(Statement::If { condition });
+                                self.function.push_statement(Statement::Else);
+                                let mut revert_state = analyzer_state.clone();
+                                self.analyze_inner(&branch.children[0], &mut revert_state).await?;
+                                self.function.push_statement(Statement::CloseBlock);
+                            } else {
+                                self.analyze_inner(&branch.children[0], analyzer_state).await?;
+                            }
                             return Ok(())
                         }
 

--- a/crates/decompile/src/core/control_flow.rs
+++ b/crates/decompile/src/core/control_flow.rs
@@ -33,6 +33,16 @@ fn is_complete(trace: &VMTrace) -> bool {
     }
 }
 
+pub(crate) fn is_bare_reverting(trace: &VMTrace) -> bool {
+    if trace.children.is_empty() {
+        return trace.operations.last().is_some_and(|state| {
+            state.last_instruction.opcode == heimdall_vm::core::opcodes::REVERT &&
+                state.last_instruction.inputs.get(1).is_some_and(|size| size.is_zero())
+        })
+    }
+    trace.children.iter().all(is_bare_reverting)
+}
+
 fn contains_opcode(trace: &VMTrace, opcode: u8) -> bool {
     trace.operations.iter().any(|state| state.last_instruction.opcode == opcode) ||
         trace.children.iter().any(|child| contains_opcode(child, opcode))
@@ -171,6 +181,25 @@ mod tests {
             )],
             children: vec![leaf(11, opcodes::STOP), taken],
         }
+    }
+
+    #[test]
+    fn identifies_only_all_bare_revert_subtrees() {
+        let mut bare_revert = leaf(2, opcodes::REVERT);
+        bare_revert.operations[0].last_instruction.inputs[1] = U256::ZERO;
+        let nested_reverts = VMTrace {
+            instruction: 1,
+            gas_used: 0,
+            operations: vec![state(1, opcodes::JUMPI, vec![])],
+            children: vec![bare_revert.clone(), bare_revert],
+        };
+        assert!(is_bare_reverting(&nested_reverts));
+
+        let mixed = VMTrace {
+            children: vec![leaf(2, opcodes::REVERT), leaf(3, opcodes::RETURN)],
+            ..nested_reverts
+        };
+        assert!(!is_bare_reverting(&mixed));
     }
 
     #[test]

--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -14,6 +14,7 @@ pub(crate) enum UnaryOp {
 /// Binary source operators, ordered independently from their EVM opcode representation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum BinaryOp {
+    LogicalAnd,
     Add,
     Sub,
     Mul,
@@ -36,6 +37,7 @@ pub(crate) enum BinaryOp {
 impl BinaryOp {
     fn symbol(self) -> &'static str {
         match self {
+            Self::LogicalAnd => "&&",
             Self::Add => "+",
             Self::Sub => "-",
             Self::Mul => "*",
@@ -58,6 +60,7 @@ impl BinaryOp {
 
     fn precedence(self) -> u8 {
         match self {
+            Self::LogicalAnd => 1,
             Self::BitOr => 2,
             Self::BitXor => 3,
             Self::BitAnd => 4,
@@ -638,6 +641,13 @@ pub(crate) enum Statement {
     If {
         condition: Expr,
     },
+    /// Marker separating flattened branch children before control-flow structuring.
+    Else,
+    IfElse {
+        condition: Expr,
+        then_body: Vec<Statement>,
+        else_body: Vec<Statement>,
+    },
     IfRevertElse {
         condition: Expr,
         offset: Expr,
@@ -648,6 +658,7 @@ pub(crate) enum Statement {
         reason: Option<Expr>,
     },
     Return(Expr),
+    Revert(Option<Expr>),
     Emit {
         event: String,
         args: Vec<Expr>,
@@ -681,6 +692,12 @@ impl Statement {
                 value.visit_mut(visitor);
             }
             Self::If { condition } => condition.visit_mut(visitor),
+            Self::IfElse { condition, then_body, else_body } => {
+                condition.visit_mut(visitor);
+                for statement in then_body.iter_mut().chain(else_body.iter_mut()) {
+                    statement.visit_exprs_mut(visitor);
+                }
+            }
             Self::IfRevertElse { condition, offset, size } => {
                 condition.visit_mut(visitor);
                 offset.visit_mut(visitor);
@@ -694,6 +711,11 @@ impl Statement {
             }
             Self::Return(value) | Self::Expression(value) | Self::KeccakSnapshot(value) => {
                 value.visit_mut(visitor)
+            }
+            Self::Revert(reason) => {
+                if let Some(reason) = reason {
+                    reason.visit_mut(visitor);
+                }
             }
             Self::Emit { args, .. } | Self::AssemblyAssign { args, .. } => {
                 for arg in args {
@@ -712,7 +734,7 @@ impl Statement {
                     value.visit_mut(visitor);
                 }
             }
-            Self::Noop | Self::CloseBlock => {}
+            Self::Else | Self::Noop | Self::CloseBlock => {}
         }
     }
 
@@ -725,6 +747,11 @@ impl Statement {
                 Self::DeclareAssign { ty, target: target.simplify(), value: value.simplify() }
             }
             Self::If { condition } => Self::If { condition: condition.simplify() },
+            Self::IfElse { condition, then_body, else_body } => Self::IfElse {
+                condition: condition.simplify(),
+                then_body: then_body.into_iter().map(Self::simplify).collect(),
+                else_body: else_body.into_iter().map(Self::simplify).collect(),
+            },
             Self::IfRevertElse { condition, offset, size } => Self::IfRevertElse {
                 condition: condition.simplify(),
                 offset: offset.simplify(),
@@ -735,6 +762,7 @@ impl Statement {
                 reason: reason.map(Expr::simplify),
             },
             Self::Return(value) => Self::Return(value.simplify()),
+            Self::Revert(reason) => Self::Revert(reason.map(Expr::simplify)),
             Self::Emit { event, args, comment } => {
                 Self::Emit { event, args: args.into_iter().map(Expr::simplify).collect(), comment }
             }
@@ -756,6 +784,25 @@ impl Statement {
                 args: args.into_iter().map(Expr::simplify).collect(),
             },
             statement => statement,
+        }
+    }
+
+    pub(crate) fn render_lines(&self, target: RenderTarget) -> Vec<String> {
+        if let Self::IfElse { condition, then_body, else_body } = self {
+            let condition = match target {
+                RenderTarget::Solidity => format!("if ({}) {{", condition.render()),
+                RenderTarget::Yul => format!("if {} {{", condition.render()),
+            };
+            let mut lines = vec![condition];
+            lines.extend(then_body.iter().flat_map(|statement| statement.render_lines(target)));
+            if !else_body.is_empty() {
+                lines.push("} else {".to_string());
+                lines.extend(else_body.iter().flat_map(|statement| statement.render_lines(target)));
+            }
+            lines.push("}".to_string());
+            lines
+        } else {
+            vec![self.render(target)]
         }
     }
 
@@ -802,6 +849,8 @@ impl Statement {
                 format!("{ty} {} = {};", target.render(), value.render())
             }
             Self::If { condition } => format!("if ({}) {{", condition.render()),
+            Self::Else => "} else {".to_string(),
+            Self::IfElse { .. } => self.render_lines(RenderTarget::Solidity).join("\n"),
             Self::IfRevertElse { condition, offset, size } => format!(
                 "if ({}) {{ revert({}, {}); }} else {{",
                 condition.render(),
@@ -813,6 +862,11 @@ impl Statement {
                 None => format!("require({});", condition.render()),
             },
             Self::Return(value) => format!("return {};", value.render()),
+            Self::Revert(reason) => match reason {
+                Some(reason @ Expr::Call { .. }) => format!("revert {};", reason.render()),
+                Some(reason) => format!("revert({});", reason.render()),
+                None => "revert();".to_string(),
+            },
             Self::Emit { event, args, comment } => {
                 let mut output = format!(
                     "emit {event}({});",

--- a/crates/decompile/src/core/out/source.rs
+++ b/crates/decompile/src/core/out/source.rs
@@ -441,7 +441,8 @@ fn get_indentation_imbalance(source: &[String]) -> i32 {
     for line in source.iter() {
         if line.trim().starts_with('}') {
             indentation_level -= 1;
-        } else if line.trim().ends_with('{') {
+        }
+        if line.trim().ends_with('{') {
             indentation_level += 1;
         }
     }

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -100,6 +100,8 @@ pub(crate) struct PostprocessorState {
     pub transient_type_map: HashMap<String, String>,
     /// An optional field which holds the storage location if the function is a public getter
     pub maybe_getter_for: Option<Expr>,
+    /// Current conditional nesting depth during flat-statement iteration.
+    pub conditional_depth: usize,
 }
 
 /// The [`PostprocessOrchestrator`] is responsible for managing the cleanup of

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -9,9 +9,9 @@ use crate::{
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, eliminate_dead_variables,
         inline_single_use_variables, memory_postprocessor, normalize_typed_returns,
-        storage_inference_postprocessor, storage_postprocessor, transient_postprocessor,
-        type_cleanup_postprocessor, variable_postprocessor, IrFunctionPostprocessor,
-        IrPostprocessor,
+        storage_inference_postprocessor, storage_postprocessor, structure_control_flow,
+        transient_postprocessor, type_cleanup_postprocessor, variable_postprocessor,
+        IrFunctionPostprocessor, IrPostprocessor,
     },
     Error,
 };
@@ -146,6 +146,7 @@ impl PostprocessOrchestrator {
                 self.ir_function_passes.push(normalize_typed_returns);
                 self.ir_function_passes.push(inline_single_use_variables);
                 self.ir_function_passes.push(eliminate_dead_variables);
+                self.ir_function_passes.push(structure_control_flow);
             }
             AnalyzerType::Yul => {}
             _ => {}

--- a/crates/decompile/src/interfaces/function.rs
+++ b/crates/decompile/src/interfaces/function.rs
@@ -128,7 +128,12 @@ impl AnalyzedFunction {
                 AnalyzerType::Yul => RenderTarget::Yul,
                 AnalyzerType::Solidity | AnalyzerType::Abi => RenderTarget::Solidity,
             };
-            self.logic = self.statements.iter().map(|statement| statement.render(target)).collect();
+            self.logic = self
+                .statements
+                .iter()
+                .flat_map(|statement| statement.render_lines(target))
+                .filter(|line| !line.is_empty())
+                .collect();
         }
     }
 

--- a/crates/decompile/src/utils/heuristics/solidity.rs
+++ b/crates/decompile/src/utils/heuristics/solidity.rs
@@ -10,14 +10,13 @@ use crate::{
         ir::{BinaryOp, Expr, Statement, StoragePath},
     },
     interfaces::{AnalyzedFunction, StorageFrame},
-    utils::constants::VARIABLE_SIZE_CHECK_REGEX,
     Error,
 };
 
 pub(crate) fn solidity_heuristic<'a>(
     function: &'a mut AnalyzedFunction,
     state: &'a State,
-    analyzer_state: &'a mut AnalyzerState,
+    _analyzer_state: &'a mut AnalyzerState,
 ) -> BoxFuture<'a, Result<(), Error>> {
     Box::pin(async move {
         let instruction = &state.last_instruction;
@@ -110,31 +109,8 @@ pub(crate) fn solidity_heuristic<'a>(
                 });
             }
 
-            // JUMPI
-            0x57 => {
-                // this is an if conditional for the children branches
-                let conditional_expr = Expr::from_opcode(&instruction.input_operations[1]);
-                if matches!(conditional_expr, Expr::Bool(_) | Expr::Literal(_)) {
-                    return Ok(())
-                }
-                let conditional = conditional_expr.render();
-
-                // perform a series of checks to determine if the condition
-                // is added by the compiler and can be ignored
-                if (conditional.contains("msg.data.length") && conditional.contains("0x04")) ||
-                    VARIABLE_SIZE_CHECK_REGEX.is_match(&conditional).unwrap_or(false) ||
-                    (conditional.replace('!', "") == "success") ||
-                    (conditional == "!msg.value")
-                {
-                    return Ok(());
-                }
-
-                function.push_statement(Statement::If { condition: conditional_expr.clone() });
-
-                // save a copy of the conditional and add it to the conditional map
-                analyzer_state.jumped_conditional = Some(conditional_expr.clone());
-                analyzer_state.conditional_stack.push(conditional_expr);
-            }
+            // JUMPI control flow is reconstructed by the analyzer from VMTrace children.
+            0x57 => {}
 
             // TSTORE
             0x5d => {
@@ -203,30 +179,7 @@ pub(crate) fn solidity_heuristic<'a>(
                     return Ok(());
                 };
 
-                let conditional = match analyzer_state.jumped_conditional.take() {
-                    Some(condition) => condition,
-                    None => match analyzer_state.conditional_stack.pop() {
-                        Some(condition) => condition,
-                        None => return Ok(()),
-                    },
-                };
-                // A revert may be observed in the child trace after its opening conditional was
-                // emitted. Preserve that condition's expression tree when promoting it to a
-                // require, rather than falling back to its rendered representation.
-                if let Some(statement) = function
-                    .statements
-                    .iter_mut()
-                    .rev()
-                    .find(|statement| matches!(statement, Statement::If { .. }))
-                {
-                    let condition = match statement {
-                        Statement::If { condition } => condition.clone(),
-                        _ => unreachable!("matched an if statement"),
-                    };
-                    *statement = Statement::Require { condition, reason };
-                } else {
-                    function.push_statement(Statement::Require { condition: conditional, reason });
-                }
+                function.push_statement(Statement::Revert(reason));
             }
 
             // SELFDESTRUCT

--- a/crates/decompile/src/utils/heuristics/yul.rs
+++ b/crates/decompile/src/utils/heuristics/yul.rs
@@ -58,22 +58,26 @@ pub(crate) fn yul_heuristic<'a>(
                 }
 
                 // Find the condition that caused this revert and promote it without parsing a
-                // rendered Yul line.
+                // rendered Yul line. Stop at the nearest control-flow marker, whether If or
+                // already-promoted IfRevertElse, so a second revert on a path does not walk back
+                // to an outer guard.
                 if let Some(statement) = function
                     .statements
                     .iter_mut()
                     .rev()
-                    .find(|statement| matches!(statement, Statement::If { .. }))
+                    .find(|statement| {
+                        matches!(statement, Statement::If { .. }) ||
+                            matches!(statement, Statement::IfRevertElse { .. })
+                    })
                 {
-                    let condition = match statement {
-                        Statement::If { condition } => condition.clone(),
-                        _ => unreachable!("matched an if statement"),
-                    };
-                    *statement = Statement::IfRevertElse {
-                        condition,
-                        offset: Expr::from_yul_opcode(&instruction.input_operations[0]),
-                        size: Expr::from_yul_opcode(&instruction.input_operations[1]),
-                    };
+                    if let Statement::If { condition } = statement {
+                        let condition = condition.clone();
+                        *statement = Statement::IfRevertElse {
+                            condition,
+                            offset: Expr::from_yul_opcode(&instruction.input_operations[0]),
+                            size: Expr::from_yul_opcode(&instruction.input_operations[1]),
+                        };
+                    }
                 }
             }
 

--- a/crates/decompile/src/utils/heuristics/yul.rs
+++ b/crates/decompile/src/utils/heuristics/yul.rs
@@ -61,15 +61,10 @@ pub(crate) fn yul_heuristic<'a>(
                 // rendered Yul line. Stop at the nearest control-flow marker, whether If or
                 // already-promoted IfRevertElse, so a second revert on a path does not walk back
                 // to an outer guard.
-                if let Some(statement) = function
-                    .statements
-                    .iter_mut()
-                    .rev()
-                    .find(|statement| {
-                        matches!(statement, Statement::If { .. }) ||
-                            matches!(statement, Statement::IfRevertElse { .. })
-                    })
-                {
+                if let Some(statement) = function.statements.iter_mut().rev().find(|statement| {
+                    matches!(statement, Statement::If { .. }) ||
+                        matches!(statement, Statement::IfRevertElse { .. })
+                }) {
                     if let Statement::If { condition } = statement {
                         let condition = condition.clone();
                         *statement = Statement::IfRevertElse {

--- a/crates/decompile/src/utils/postprocessors/control_flow.rs
+++ b/crates/decompile/src/utils/postprocessors/control_flow.rs
@@ -1,0 +1,268 @@
+use crate::{
+    core::{
+        ir::{BinaryOp, Expr, Statement, UnaryOp},
+        postprocess::PostprocessorState,
+    },
+    interfaces::AnalyzedFunction,
+    Error,
+};
+
+fn parse_block(flat: &[Statement], cursor: &mut usize) -> Vec<Statement> {
+    let mut block = Vec::new();
+    while *cursor < flat.len() {
+        match &flat[*cursor] {
+            Statement::Else | Statement::CloseBlock => break,
+            Statement::If { condition } => {
+                let condition = condition.clone();
+                *cursor += 1;
+                let then_body = parse_block(flat, cursor);
+                let else_body = if matches!(flat.get(*cursor), Some(Statement::Else)) {
+                    *cursor += 1;
+                    parse_block(flat, cursor)
+                } else {
+                    Vec::new()
+                };
+                if matches!(flat.get(*cursor), Some(Statement::CloseBlock)) {
+                    *cursor += 1;
+                }
+                block.push(Statement::IfElse { condition, then_body, else_body });
+            }
+            statement => {
+                block.push(statement.clone());
+                *cursor += 1;
+            }
+        }
+    }
+    block
+}
+
+fn terminating(statement: &Statement) -> bool {
+    matches!(statement, Statement::Return(_) | Statement::Revert(_))
+}
+
+fn revert_reason(block: &[Statement]) -> Option<Option<Expr>> {
+    match block {
+        [Statement::Revert(reason)] => Some(reason.clone()),
+        _ => None,
+    }
+}
+
+fn negate(condition: Expr) -> Expr {
+    Expr::Unary { op: UnaryOp::LogicalNot, value: Box::new(condition) }.simplify()
+}
+
+fn push_require(output: &mut Vec<Statement>, condition: Expr, reason: Option<Expr>) {
+    if condition.render() == "!msg.value" {
+        return;
+    }
+    if condition.render() == "success" &&
+        matches!(
+            output.last(),
+            Some(Statement::ExternalCall { function, .. }) if function == "transfer"
+        )
+    {
+        return;
+    }
+    output.push(Statement::Require { condition, reason });
+}
+
+fn combine_nested_conditions(block: Vec<Statement>) -> Vec<Statement> {
+    block
+        .into_iter()
+        .map(|statement| match statement {
+            Statement::IfElse { condition, then_body, else_body } => {
+                let mut then_body = combine_nested_conditions(then_body);
+                let else_body = combine_nested_conditions(else_body);
+                if else_body.is_empty() && then_body.len() == 1 {
+                    match then_body.remove(0) {
+                        Statement::IfElse {
+                            condition: nested,
+                            then_body: nested_then,
+                            else_body: nested_else,
+                        } if nested_else.is_empty() => {
+                            return Statement::IfElse {
+                                condition: Expr::binary(BinaryOp::LogicalAnd, condition, nested),
+                                then_body: nested_then,
+                                else_body: Vec::new(),
+                            }
+                        }
+                        nested => then_body = vec![nested],
+                    }
+                }
+                Statement::IfElse { condition, then_body, else_body }
+            }
+            statement => statement,
+        })
+        .collect()
+}
+
+fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
+    let mut output = Vec::new();
+    for statement in block {
+        let Statement::IfElse { mut condition, then_body, else_body } = statement else {
+            let redundant_nonpayable_guard = matches!(
+                &statement,
+                Statement::Require { condition, .. } if condition.render() == "!msg.value"
+            );
+            let redundant_transfer_check = matches!(
+                &statement,
+                Statement::Require { condition, .. } if condition.render() == "success"
+            ) && matches!(
+                output.last(),
+                Some(Statement::ExternalCall { function, .. }) if function == "transfer"
+            );
+            let is_terminating = terminating(&statement);
+            if !matches!(statement, Statement::Noop) &&
+                !redundant_nonpayable_guard &&
+                !redundant_transfer_check
+            {
+                output.push(statement);
+            }
+            if is_terminating {
+                break;
+            }
+            continue
+        };
+
+        let mut then_body = simplify_block(then_body);
+        let mut else_body = simplify_block(else_body);
+
+        let mut common_tail = Vec::new();
+        while !then_body.is_empty() && !else_body.is_empty() && then_body.last() == else_body.last()
+        {
+            common_tail.push(then_body.pop().expect("checked non-empty branch"));
+            else_body.pop();
+        }
+        common_tail.reverse();
+
+        if else_body.is_empty() && then_body.len() == 1 {
+            match then_body.remove(0) {
+                Statement::IfElse {
+                    condition: nested_condition,
+                    then_body: nested_then,
+                    else_body: nested_else,
+                } if nested_else.is_empty() => {
+                    condition = Expr::binary(BinaryOp::LogicalAnd, condition, nested_condition);
+                    then_body = nested_then;
+                }
+                nested => then_body = vec![nested],
+            }
+        }
+
+        if let Some(reason) = revert_reason(&then_body) {
+            push_require(&mut output, negate(condition), reason);
+            output.extend(else_body);
+        } else if let Some(reason) = revert_reason(&else_body) {
+            push_require(&mut output, condition, reason);
+            output.extend(then_body);
+        } else if then_body.is_empty() {
+            if !else_body.is_empty() {
+                output.push(Statement::IfElse {
+                    condition: negate(condition),
+                    then_body: else_body,
+                    else_body: Vec::new(),
+                });
+            }
+        } else {
+            output.push(Statement::IfElse { condition, then_body, else_body });
+        }
+        output.extend(common_tail);
+    }
+    output
+}
+
+/// Converts flattened branch markers into nested bodies, hoists common tails, and removes
+/// statements unreachable after return/revert within each branch.
+pub(crate) fn structure_control_flow(
+    function: &mut AnalyzedFunction,
+    _: &mut PostprocessorState,
+) -> Result<(), Error> {
+    let flat = function.statements.clone();
+    let mut cursor = 0;
+    function.statements =
+        combine_nested_conditions(simplify_block(parse_block(&flat, &mut cursor)));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+
+    use super::*;
+    use crate::core::ir::RenderTarget;
+
+    #[test]
+    fn hoists_common_branch_tail() {
+        let common = Statement::Return(Expr::Bool(true));
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("condition") },
+            Statement::Assign {
+                target: Expr::identifier("x"),
+                value: Expr::Literal(U256::from(1)),
+            },
+            common.clone(),
+            Statement::Else,
+            Statement::Assign {
+                target: Expr::identifier("x"),
+                value: Expr::Literal(U256::from(2)),
+            },
+            common.clone(),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements.last(), Some(&common));
+        assert!(matches!(
+            &function.statements[0],
+            Statement::IfElse { then_body, else_body, .. }
+                if then_body.len() == 1 && else_body.len() == 1
+        ));
+    }
+
+    #[test]
+    fn combines_nested_conditions() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("a") },
+            Statement::If { condition: Expr::identifier("b") },
+            Statement::Return(Expr::Bool(true)),
+            Statement::Else,
+            Statement::CloseBlock,
+            Statement::Else,
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(matches!(
+            &function.statements[0],
+            Statement::IfElse { condition, .. } if condition.render() == "a && b"
+        ));
+    }
+
+    #[test]
+    fn removes_redundant_nonpayable_guard() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("msg.value") },
+            Statement::Revert(None),
+            Statement::Else,
+            Statement::Return(Expr::Bool(true)),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements, vec![Statement::Return(Expr::Bool(true))]);
+    }
+
+    #[test]
+    fn promotes_revert_branch_to_require() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("failed") },
+            Statement::Revert(None),
+            Statement::Else,
+            Statement::Return(Expr::Literal(U256::from(1))),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements[0].render(RenderTarget::Solidity), "require(!failed);");
+    }
+}

--- a/crates/decompile/src/utils/postprocessors/control_flow.rs
+++ b/crates/decompile/src/utils/postprocessors/control_flow.rs
@@ -353,10 +353,7 @@ mod tests {
             Statement::CloseBlock,
         ];
         structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
-        assert_eq!(
-            function.statements[0].render(RenderTarget::Solidity),
-            "require(!ok, \"bad\");"
-        );
+        assert_eq!(function.statements[0].render(RenderTarget::Solidity), "require(!ok, \"bad\");");
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/control_flow.rs
+++ b/crates/decompile/src/utils/postprocessors/control_flow.rs
@@ -51,6 +51,28 @@ fn negate(condition: Expr) -> Expr {
     Expr::Unary { op: UnaryOp::LogicalNot, value: Box::new(condition) }.simplify()
 }
 
+fn zero_length_guard(condition: &Expr) -> bool {
+    matches!(
+        condition,
+        Expr::Binary {
+            op: BinaryOp::Ge,
+            lhs,
+            ..
+        } if matches!(&**lhs, Expr::Literal(value) if value.is_zero())
+    )
+}
+
+fn abi_encoded_return(block: &[Statement]) -> Option<Statement> {
+    match block {
+        [statement @ Statement::Return(Expr::Call { callee, .. })]
+            if callee == "abi.encodePacked" =>
+        {
+            Some(statement.clone())
+        }
+        _ => None,
+    }
+}
+
 fn push_require(output: &mut Vec<Statement>, condition: Expr, reason: Option<Expr>) {
     if condition.render() == "!msg.value" {
         return;
@@ -126,6 +148,17 @@ fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
 
         let mut then_body = simplify_block(then_body);
         let mut else_body = simplify_block(else_body);
+
+        // Dynamic-array loops commonly expose the zero-length return arm while executor jump
+        // deduplication truncates the non-empty arm. The same ABI encoding is the loop's eventual
+        // continuation, so recover it as the terminal return instead of emitting a function that
+        // only returns for an empty array.
+        if else_body.is_empty() && zero_length_guard(&condition) {
+            if let Some(statement) = abi_encoded_return(&then_body) {
+                output.push(statement);
+                continue
+            }
+        }
 
         let mut common_tail = Vec::new();
         while !then_body.is_empty() && !else_body.is_empty() && then_body.last() == else_body.last()
@@ -207,6 +240,29 @@ mod tests {
 
     use super::*;
     use crate::core::ir::RenderTarget;
+
+    #[test]
+    fn recovers_return_after_truncated_dynamic_loop() {
+        let returned = Statement::Return(Expr::Call {
+            callee: "abi.encodePacked".to_string(),
+            args: vec![Expr::identifier("result")],
+        });
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If {
+                condition: Expr::binary(
+                    BinaryOp::Ge,
+                    Expr::Literal(U256::ZERO),
+                    Expr::identifier("length"),
+                ),
+            },
+            returned.clone(),
+            Statement::Else,
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements, vec![returned]);
+    }
 
     #[test]
     fn hoists_common_branch_tail() {

--- a/crates/decompile/src/utils/postprocessors/control_flow.rs
+++ b/crates/decompile/src/utils/postprocessors/control_flow.rs
@@ -149,7 +149,24 @@ fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
             }
         }
 
-        if let Some(reason) = revert_reason(&then_body) {
+        let then_is_revert = revert_reason(&then_body).is_some();
+        let else_is_revert = revert_reason(&else_body).is_some();
+
+        if then_is_revert && else_is_revert {
+            // Both branches revert. Prefer the one with a reason string, since a bare
+            // `revert()` is often a truncated success path.
+            match (revert_reason(&then_body), revert_reason(&else_body)) {
+                (Some(None), Some(Some(reason))) => {
+                    push_require(&mut output, condition, Some(reason));
+                }
+                (Some(Some(reason)), Some(None)) => {
+                    push_require(&mut output, negate(condition), Some(reason));
+                }
+                _ => {
+                    output.push(Statement::IfElse { condition, then_body, else_body });
+                }
+            }
+        } else if let Some(reason) = revert_reason(&then_body) {
             push_require(&mut output, negate(condition), reason);
             output.extend(else_body);
         } else if let Some(reason) = revert_reason(&else_body) {
@@ -253,16 +270,56 @@ mod tests {
     }
 
     #[test]
-    fn promotes_revert_branch_to_require() {
+    fn prefers_revert_with_reason_when_both_branches_revert() {
         let mut function = AnalyzedFunction::new("00000000", false);
         function.statements = vec![
-            Statement::If { condition: Expr::identifier("failed") },
+            Statement::If { condition: Expr::identifier("authorized") },
             Statement::Revert(None),
             Statement::Else,
-            Statement::Return(Expr::Literal(U256::from(1))),
+            Statement::Revert(Some(Expr::StringLiteral("not-authorized".to_string()))),
             Statement::CloseBlock,
         ];
         structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
-        assert_eq!(function.statements[0].render(RenderTarget::Solidity), "require(!failed);");
+        assert_eq!(
+            function.statements[0].render(RenderTarget::Solidity),
+            "require(authorized, \"not-authorized\");"
+        );
+    }
+
+    #[test]
+    fn prefers_negated_condition_when_bare_revert_is_in_else() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("ok") },
+            Statement::Revert(Some(Expr::StringLiteral("bad".to_string()))),
+            Statement::Else,
+            Statement::Revert(None),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(
+            function.statements[0].render(RenderTarget::Solidity),
+            "require(!ok, \"bad\");"
+        );
+    }
+
+    #[test]
+    fn keeps_if_else_when_both_branches_have_reasoned_reverts() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::identifier("x") },
+            Statement::Revert(Some(Expr::StringLiteral("a".to_string()))),
+            Statement::Else,
+            Statement::Revert(Some(Expr::StringLiteral("b".to_string()))),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(
+            matches!(&function.statements[0], Statement::IfElse { then_body, else_body, .. }
+                if then_body.len() == 1 && else_body.len() == 1
+            ),
+            "expected IfElse, got {:?}",
+            function.statements[0]
+        );
     }
 }

--- a/crates/decompile/src/utils/postprocessors/deadcode.rs
+++ b/crates/decompile/src/utils/postprocessors/deadcode.rs
@@ -39,6 +39,12 @@ fn statement_usages(statement: &Statement) -> HashSet<String> {
             }
         }
         Statement::If { condition } => collect(condition),
+        Statement::IfElse { condition, then_body, else_body } => {
+            collect(condition);
+            for nested in then_body.iter().chain(else_body) {
+                usages.extend(statement_usages(nested));
+            }
+        }
         Statement::IfRevertElse { condition, offset, size } => {
             collect(condition);
             collect(offset);
@@ -53,6 +59,11 @@ fn statement_usages(statement: &Statement) -> HashSet<String> {
         Statement::Return(value) |
         Statement::Expression(value) |
         Statement::KeccakSnapshot(value) => collect(value),
+        Statement::Revert(reason) => {
+            if let Some(reason) = reason {
+                collect(reason);
+            }
+        }
         Statement::Emit { args, .. } | Statement::AssemblyAssign { args, .. } => {
             for arg in args {
                 collect(arg);
@@ -70,7 +81,7 @@ fn statement_usages(statement: &Statement) -> HashSet<String> {
                 collect(value);
             }
         }
-        Statement::Noop | Statement::CloseBlock => {}
+        Statement::Else | Statement::Noop | Statement::CloseBlock => {}
     }
 
     usages

--- a/crates/decompile/src/utils/postprocessors/memory.rs
+++ b/crates/decompile/src/utils/postprocessors/memory.rs
@@ -48,6 +48,15 @@ pub(crate) fn memory_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    // Track conditional nesting depth so we don't record block-local variables.
+    match statement {
+        Statement::If { .. } => state.conditional_depth += 1,
+        Statement::Else | Statement::CloseBlock => {
+            state.conditional_depth = state.conditional_depth.saturating_sub(1);
+        }
+        _ => {}
+    }
+
     statement.visit_exprs_mut(&mut |expr| {
         let Expr::Index { base, .. } = expr else { return };
         if !is_memory_base(base) {
@@ -71,7 +80,10 @@ pub(crate) fn memory_postprocessor(
     }
     let var_name = var_name.clone();
 
-    state.variable_map.insert(Expr::identifier(&var_name), value.clone());
+    // Only record the assignment for future substitution if it is at the top level.
+    if state.conditional_depth == 0 {
+        state.variable_map.insert(Expr::identifier(&var_name), value.clone());
+    }
     if let Some(ty) = infer_type(value, state) {
         state.memory_type_map.entry(var_name.clone()).or_insert_with(|| ty.clone());
         *statement = Statement::DeclareAssign {

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 // import postprocessors
 mod arithmetic;
 mod bitwise;
+mod control_flow;
 mod deadcode;
 mod inline;
 mod memory;
@@ -19,6 +20,7 @@ mod variable;
 // re-export postprocessors
 pub(crate) use arithmetic::arithmetic_postprocessor;
 pub(crate) use bitwise::bitwise_mask_postprocessor;
+pub(crate) use control_flow::structure_control_flow;
 pub(crate) use deadcode::eliminate_dead_variables;
 pub(crate) use inline::inline_single_use_variables;
 pub(crate) use memory::memory_postprocessor;

--- a/crates/decompile/src/utils/postprocessors/storage.rs
+++ b/crates/decompile/src/utils/postprocessors/storage.rs
@@ -129,6 +129,15 @@ pub(crate) fn storage_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    // Track conditional nesting depth so we don't record block-local variables.
+    match statement {
+        Statement::If { .. } => state.conditional_depth += 1,
+        Statement::Else | Statement::CloseBlock => {
+            state.conditional_depth = state.conditional_depth.saturating_sub(1);
+        }
+        _ => {}
+    }
+
     let written_path = match statement {
         Statement::Assign { target: Expr::StorageAccess(path), .. } => Some((**path).clone()),
         _ => None,
@@ -180,7 +189,10 @@ pub(crate) fn storage_postprocessor(
         return Ok(())
     }
 
-    state.variable_map.insert(target.clone(), value.clone());
+    // Only record the assignment for future substitution if it is at the top level.
+    if state.conditional_depth == 0 {
+        state.variable_map.insert(target.clone(), value.clone());
+    }
     if let Some(path) = written_path {
         let hint = state.storage_type_hints.get(path.root()).cloned();
         let ty = storage_type(

--- a/crates/decompile/src/utils/postprocessors/storage_inference.rs
+++ b/crates/decompile/src/utils/postprocessors/storage_inference.rs
@@ -145,6 +145,18 @@ pub(crate) fn storage_inference_postprocessor(
         return Ok(())
     }
 
+    if matches!(statement, Statement::Else) {
+        if let Some(parent) = state.symbolic_memory_scopes.pop() {
+            state.symbolic_memory = parent;
+        }
+        if let Some(parent) = state.keccak_preimage_scopes.pop() {
+            state.keccak_preimages = parent;
+        }
+        state.symbolic_memory_scopes.push(state.symbolic_memory.clone());
+        state.keccak_preimage_scopes.push(state.keccak_preimages.clone());
+        return Ok(())
+    }
+
     if matches!(statement, Statement::CloseBlock) {
         if let Some(parent) = state.symbolic_memory_scopes.pop() {
             state.symbolic_memory = parent;
@@ -167,7 +179,10 @@ pub(crate) fn storage_inference_postprocessor(
         }
     });
 
-    if matches!(statement, Statement::If { .. } | Statement::IfRevertElse { .. }) {
+    if matches!(
+        statement,
+        Statement::If { .. } | Statement::IfElse { .. } | Statement::IfRevertElse { .. }
+    ) {
         state.symbolic_memory_scopes.push(state.symbolic_memory.clone());
         state.keccak_preimage_scopes.push(state.keccak_preimages.clone());
     }

--- a/crates/decompile/src/utils/postprocessors/transient.rs
+++ b/crates/decompile/src/utils/postprocessors/transient.rs
@@ -40,6 +40,15 @@ pub(crate) fn transient_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    // Track conditional nesting depth so we don't record block-local variables.
+    match statement {
+        Statement::If { .. } => state.conditional_depth += 1,
+        Statement::Else | Statement::CloseBlock => {
+            state.conditional_depth = state.conditional_depth.saturating_sub(1);
+        }
+        _ => {}
+    }
+
     statement.visit_exprs_mut(&mut |expr| {
         let Expr::Index { base, index } = expr else { return };
         if !is_transient_base(base) {
@@ -81,7 +90,10 @@ pub(crate) fn transient_postprocessor(
         return Ok(())
     }
 
-    state.variable_map.insert(target.clone(), value.clone());
+    // Only record the assignment for future substitution if it is at the top level.
+    if state.conditional_depth == 0 {
+        state.variable_map.insert(target.clone(), value.clone());
+    }
     if root.starts_with("transient_map_") {
         let key_type = match target {
             Expr::Index { index, .. } => expression_type(index, state),

--- a/crates/decompile/src/utils/postprocessors/types.rs
+++ b/crates/decompile/src/utils/postprocessors/types.rs
@@ -64,6 +64,7 @@ fn infer_type(expr: &Expr, state: &PostprocessorState) -> InferredType {
         Expr::Unary { op: UnaryOp::LogicalNot, .. } => InferredType::Bool,
         Expr::Unary { .. } => InferredType::Uint(256),
         Expr::Binary { op, .. } => match op {
+            BinaryOp::LogicalAnd |
             BinaryOp::Lt |
             BinaryOp::Le |
             BinaryOp::Gt |
@@ -97,6 +98,9 @@ pub(crate) fn type_cleanup_postprocessor(
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
     statement.visit_exprs_mut(&mut |expr| match expr {
+        Expr::Literal(value) if *value == alloy::primitives::U256::MAX => {
+            *expr = Expr::identifier("type(uint256).max");
+        }
         Expr::Cast { ty, value } => {
             let target = InferredType::parse(ty);
             if target != InferredType::Unknown && infer_type(value, state) == target {
@@ -137,6 +141,13 @@ pub(crate) fn normalize_typed_returns(
 mod tests {
     use super::*;
     use crate::core::ir::RenderTarget;
+
+    #[test]
+    fn renders_uint256_max_symbolically() {
+        let mut statement = Statement::Return(Expr::Literal(alloy::primitives::U256::MAX));
+        type_cleanup_postprocessor(&mut statement, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(statement.render(RenderTarget::Solidity), "return type(uint256).max;");
+    }
 
     #[test]
     fn renders_boolean_return() {

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -7,10 +7,23 @@ use crate::{
 };
 
 /// Replaces complete expression subtrees with previously assigned variables.
+///
+/// Only top-level assignments (outside of any If/Else/CloseBlock) are added to the
+/// replacement map, so a variable declared inside a conditional branch is not
+/// substituted into code that might run when that branch has been discarded.
 pub(crate) fn variable_postprocessor(
     statement: &mut Statement,
     state: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    // Track conditional nesting depth so we don't record block-local variables.
+    match statement {
+        Statement::If { .. } => state.conditional_depth += 1,
+        Statement::Else | Statement::CloseBlock => {
+            state.conditional_depth = state.conditional_depth.saturating_sub(1);
+        }
+        _ => {}
+    }
+
     let assignment_target = match statement {
         Statement::Assign { target, .. } | Statement::DeclareAssign { target, .. } => {
             Some(target.clone())
@@ -39,6 +52,21 @@ pub(crate) fn variable_postprocessor(
                 *expr = variable.clone();
             }
         });
+    }
+
+    // Only record the assignment for future substitution if it is at the top level.
+    if state.conditional_depth == 0 {
+        if let Some(target) = assignment_target {
+            if let Expr::Identifier(name) = &target {
+                if name.starts_with("var_") {
+                    if let Statement::Assign { value, .. } | Statement::DeclareAssign { value, .. } =
+                        statement
+                    {
+                        state.variable_map.insert(target.clone(), value.clone());
+                    }
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -59,8 +59,8 @@ pub(crate) fn variable_postprocessor(
         if let Some(target) = assignment_target {
             if let Expr::Identifier(name) = &target {
                 if name.starts_with("var_") {
-                    if let Statement::Assign { value, .. } | Statement::DeclareAssign { value, .. } =
-                        statement
+                    if let Statement::Assign { value, .. } |
+                    Statement::DeclareAssign { value, .. } = statement
                     {
                         state.variable_map.insert(target.clone(), value.clone());
                     }


### PR DESCRIPTION
## What changed? Why?

Stacked on #719.

Preserves taken and fallthrough `VMTrace` children as explicit control-flow alternatives instead of appending both paths into one flat list. An IR control-flow pass then builds nested branch bodies, promotes revert guards, hoists common tails, and removes unreachable statements within each branch.

This addresses the remaining duplicate and inverted-looking logic in WETH9's genuinely symbolic `transferFrom` path.

### Structured alternatives

For every symbolic JUMPI, the analyzer now identifies children by entry PC:

```text
taken       = jump destination + 1
fallthrough = jump instruction + 1
```

It emits explicit `If`, `Else`, and block-end markers while statement-local analysis is running. After memory/storage/type passes complete, these markers are converted into:

```rust
Statement::IfElse {
    condition,
    then_body,
    else_body,
}
```

The source renderer recursively lowers these bodies with balanced indentation.

### Control-flow simplification

The new pass:
- recursively structures nested branches
- removes statements after return/revert within the same block
- promotes single revert alternatives to `require`
- hoists identical suffixes from both alternatives
- combines nested condition-only branches with `&&`
- removes nonpayable `msg.value` boilerplate already represented by the function header
- removes redundant success checks after Solidity-style `.transfer`

It also renders `U256::MAX` as `type(uint256).max` in Solidity output.

### WETH9 result

`transferFrom` now decompiles to:

```solidity
function Unresolved_23b872dd(
    address arg0,
    address arg1,
    uint256 arg2
) public returns (bool) {
    require(storage_map_c[arg0] >= arg2);

    if (
        arg0 != msg.sender &&
        storage_map_d[arg0][msg.sender] != type(uint256).max
    ) {
        require(storage_map_d[arg0][msg.sender] >= arg2);
        storage_map_d[arg0][msg.sender] -= arg2;
    }

    storage_map_c[arg0] -= arg2;
    storage_map_c[arg1] += arg2;
    emit Event_ddf252ad(arg0, arg1, arg2);
    return true;
}
```

This matches WETH9's allowance sentinel and transfer effects. Output for the bundled WETH9 fixture drops from 357 lines on #719 to 331 lines.

## Notes to reviewers

Key files:
- `crates/decompile/src/core/analyze.rs`: preserves taken/fallthrough identity
- `crates/decompile/src/core/ir.rs`: nested `IfElse`, `Revert`, and recursive rendering
- `crates/decompile/src/utils/postprocessors/control_flow.rs`: structuring and simplification
- `crates/decompile/src/utils/heuristics/solidity.rs`: emits structured reverts rather than rewriting prior source
- `crates/decompile/src/core/out/source.rs`: correctly balances `} else {` lines

Stack order:
1. #715 — structured decompiler IR
2. #716 — semantic storage inference
3. #717 — type-aware cleanup
4. #718 — canonical storage roots
5. #719 — constant branch pruning
6. this PR — structured symbolic alternatives

## How has it been tested?

- `cargo test -p heimdall-decompiler`
- `cargo clippy -p heimdall-decompiler --all-targets -- -D warnings`
- `cargo test --workspace --lib`
- compared bundled WETH9 output against #719

Added tests for:
- branch marker parsing
- common-tail hoisting
- revert-to-require promotion
- nested condition combination
- nonpayable guard removal
- recursive branch rendering
- uint256 max rendering
