### PR TITLE
feat(decompile): simplify tautological IR guards

### DIFF
--- a/crates/decompile/src/core/ir.rs
+++ b/crates/decompile/src/core/ir.rs
@@ -438,6 +438,29 @@ impl Expr {
         visitor(self);
     }
 
+    /// Whether evaluating this expression has no observable effects and may safely be deduplicated.
+    ///
+    /// This deliberately excludes raw opcode renderings, calls, and storage/memory accesses. Those
+    /// can conceal reads or calls whose repeated evaluation must remain visible in decompiled code.
+    fn is_duplicate_safe(&self) -> bool {
+        match self {
+            Self::Empty |
+            Self::Identifier(_) |
+            Self::Literal(_) |
+            Self::Bool(_) |
+            Self::StringLiteral(_) => true,
+            Self::Unary { value, .. } | Self::Cast { value, .. } => value.is_duplicate_safe(),
+            Self::Binary { lhs, rhs, .. } => lhs.is_duplicate_safe() && rhs.is_duplicate_safe(),
+            Self::Raw(_) |
+            Self::Index { .. } |
+            Self::Slice { .. } |
+            Self::Member { .. } |
+            Self::Keccak { .. } |
+            Self::StorageAccess(_) |
+            Self::Call { .. } => false,
+        }
+    }
+
     /// Apply local, semantics-preserving simplifications before source rendering.
     pub(crate) fn simplify(self) -> Self {
         match self {
@@ -501,6 +524,19 @@ impl Expr {
                     (BinaryOp::Mul, Self::Literal(value), _) if *value == U256::from(1) => rhs,
                     (BinaryOp::BitAnd, _, Self::Literal(value)) if *value == U256::MAX => lhs,
                     (BinaryOp::BitAnd, Self::Literal(value), _) if *value == U256::MAX => rhs,
+                    (BinaryOp::BitAnd | BinaryOp::BitOr, ..)
+                        if lhs == rhs && lhs.is_duplicate_safe() =>
+                    {
+                        lhs
+                    }
+                    (BinaryOp::LogicalAnd, Self::Bool(true), _) => rhs,
+                    (BinaryOp::LogicalAnd, _, Self::Bool(true)) => lhs,
+                    (BinaryOp::LogicalAnd, Self::Bool(false), _) if rhs.is_duplicate_safe() => {
+                        Self::Bool(false)
+                    }
+                    (BinaryOp::LogicalAnd, _, Self::Bool(false)) if lhs.is_duplicate_safe() => {
+                        Self::Bool(false)
+                    }
                     (BinaryOp::BitAnd, _, Self::Literal(mask)) => {
                         Self::mask_cast(lhs.clone(), *mask).unwrap_or_else(|| Self::Binary {
                             op,
@@ -1019,6 +1055,37 @@ mod tests {
             vec![U256::from(1).into(), U256::from(2).into(), U256::from(3).into()],
         );
         assert_eq!(Expr::from_opcode(&addmod).render(), "(0x01 + 0x02) % 0x03");
+    }
+
+    #[test]
+    fn simplifies_duplicate_safe_identities() {
+        let identifier = Expr::identifier("arg0");
+        assert_eq!(
+            Expr::binary(BinaryOp::BitAnd, identifier.clone(), identifier.clone()).render(),
+            "arg0"
+        );
+        assert_eq!(Expr::binary(BinaryOp::BitOr, identifier.clone(), identifier).render(), "arg0");
+    }
+
+    #[test]
+    fn does_not_fold_effectful_duplicate_expressions() {
+        let call = Expr::Call { callee: "unknown".to_string(), args: vec![] };
+        assert!(matches!(
+            Expr::binary(BinaryOp::BitAnd, call.clone(), call),
+            Expr::Binary { op: BinaryOp::BitAnd, .. }
+        ));
+    }
+
+    #[test]
+    fn simplifies_boolean_identities() {
+        assert_eq!(
+            Expr::binary(BinaryOp::LogicalAnd, Expr::Bool(true), Expr::identifier("ok")).render(),
+            "ok"
+        );
+        assert_eq!(
+            Expr::binary(BinaryOp::LogicalAnd, Expr::Bool(false), Expr::identifier("ok")).render(),
+            "false"
+        );
     }
 
     #[test]

--- a/crates/decompile/src/utils/postprocessors/control_flow.rs
+++ b/crates/decompile/src/utils/postprocessors/control_flow.rs
@@ -1,3 +1,5 @@
+use alloy::primitives::U256;
+
 use crate::{
     core::{
         ir::{BinaryOp, Expr, Statement, UnaryOp},
@@ -73,15 +75,96 @@ fn abi_encoded_return(block: &[Statement]) -> Option<Statement> {
     }
 }
 
-fn is_compiler_guard(condition: &Expr) -> bool {
-    matches!(condition, Expr::Bool(true)) || condition.render().contains("msg.data.length")
+fn is_trivial_guard(condition: &Expr) -> bool {
+    matches!(condition, Expr::Bool(true))
+}
+
+fn is_nonpayable_guard(condition: &Expr) -> bool {
+    matches!(
+        condition,
+        Expr::Unary { op: UnaryOp::LogicalNot, value }
+            if matches!(&**value, Expr::Identifier(name) if name == "msg.value")
+    )
+}
+
+fn is_success_identifier(condition: &Expr) -> bool {
+    matches!(condition, Expr::Identifier(name) if name == "success")
+}
+
+fn is_calldata_length(expr: &Expr) -> bool {
+    matches!(expr, Expr::Identifier(name) if name == "msg.data.length")
+}
+
+fn is_argument(expr: &Expr) -> bool {
+    matches!(expr, Expr::Identifier(name) if name.strip_prefix("arg").is_some_and(|index| !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit())) )
+}
+
+/// Returns whether an expression is composed exclusively from ABI offset arithmetic and whether
+/// it contains evidence that it is relative to calldata rather than a user-defined numeric check.
+fn calldata_offset(expr: &Expr) -> Option<bool> {
+    match expr {
+        Expr::Literal(value) => Some(*value == U256::from(4)),
+        Expr::Identifier(_) if is_argument(expr) => Some(false),
+        Expr::Cast { value, .. } => calldata_offset(value),
+        Expr::Index { base, index } if matches!(&**base, Expr::Identifier(name) if name == "msg.data") => {
+            calldata_offset(index).map(|_| true)
+        }
+        Expr::Binary { op, lhs, rhs }
+            if matches!(op, BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Shl) =>
+        {
+            Some(calldata_offset(lhs)? || calldata_offset(rhs)?)
+        }
+        _ => None,
+    }
+}
+
+/// Match only canonical ABI bounds checks, not arbitrary conditions that mention calldata size.
+fn is_calldata_validity_guard(condition: &Expr) -> bool {
+    let Expr::Binary { op, lhs, rhs } = condition else { return false };
+
+    match op {
+        // `msg.data.length - offset >= required`.
+        BinaryOp::Ge | BinaryOp::Gt => {
+            let Expr::Binary { op: BinaryOp::Sub, lhs: available, rhs: offset } = &**lhs else {
+                return false;
+            };
+            is_calldata_length(available) &&
+                calldata_offset(offset).is_some_and(|evidence| evidence) &&
+                calldata_offset(rhs).is_some()
+        }
+        // `offset < msg.data.length`.
+        BinaryOp::Lt | BinaryOp::Le => {
+            is_calldata_length(rhs) && calldata_offset(lhs).is_some_and(|evidence| evidence)
+        }
+        _ => false,
+    }
+}
+
+/// Remove only proven ABI bounds-check conjuncts, preserving every other condition.
+fn remove_calldata_validity_conjuncts(condition: Expr) -> Expr {
+    let Expr::Binary { op: BinaryOp::LogicalAnd, lhs, rhs } = condition else {
+        return condition;
+    };
+    let lhs = remove_calldata_validity_conjuncts(*lhs);
+    let rhs = remove_calldata_validity_conjuncts(*rhs);
+
+    if is_calldata_validity_guard(&lhs) {
+        rhs
+    } else if is_calldata_validity_guard(&rhs) {
+        lhs
+    } else {
+        Expr::binary(BinaryOp::LogicalAnd, lhs, rhs)
+    }
 }
 
 fn push_require(output: &mut Vec<Statement>, condition: Expr, reason: Option<Expr>) {
-    if condition.render() == "!msg.value" || is_compiler_guard(&condition) {
+    if is_trivial_guard(&condition) ||
+        is_nonpayable_guard(&condition) ||
+        is_calldata_validity_guard(&condition)
+    {
         return;
     }
-    if condition.render() == "success" &&
+    if is_success_identifier(&condition) &&
         matches!(
             output.last(),
             Some(Statement::ExternalCall { function, .. }) if function == "transfer"
@@ -97,6 +180,7 @@ fn combine_nested_conditions(block: Vec<Statement>) -> Vec<Statement> {
         .into_iter()
         .map(|statement| match statement {
             Statement::IfElse { condition, then_body, else_body } => {
+                let condition = remove_calldata_validity_conjuncts(condition);
                 let mut then_body = combine_nested_conditions(then_body);
                 let else_body = combine_nested_conditions(else_body);
                 if else_body.is_empty() && then_body.len() == 1 {
@@ -107,7 +191,11 @@ fn combine_nested_conditions(block: Vec<Statement>) -> Vec<Statement> {
                             else_body: nested_else,
                         } if nested_else.is_empty() => {
                             return Statement::IfElse {
-                                condition: Expr::binary(BinaryOp::LogicalAnd, condition, nested),
+                                condition: remove_calldata_validity_conjuncts(Expr::binary(
+                                    BinaryOp::LogicalAnd,
+                                    condition,
+                                    nested,
+                                )),
                                 then_body: nested_then,
                                 else_body: Vec::new(),
                             }
@@ -129,11 +217,13 @@ fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
             let redundant_guard = matches!(
                 &statement,
                 Statement::Require { condition, .. }
-                    if condition.render() == "!msg.value" || is_compiler_guard(condition)
+                    if is_trivial_guard(condition) ||
+                        is_nonpayable_guard(condition) ||
+                        is_calldata_validity_guard(condition)
             );
             let redundant_transfer_check = matches!(
                 &statement,
-                Statement::Require { condition, .. } if condition.render() == "success"
+                Statement::Require { condition, .. } if is_success_identifier(condition)
             ) && matches!(
                 output.last(),
                 Some(Statement::ExternalCall { function, .. }) if function == "transfer"
@@ -148,11 +238,20 @@ fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
             if is_terminating {
                 break;
             }
-            continue
+            continue;
         };
 
+        condition = remove_calldata_validity_conjuncts(condition);
         let mut then_body = simplify_block(then_body);
         let mut else_body = simplify_block(else_body);
+
+        // Trace deduplication can make a syntactically constant branch share continuation blocks
+        // with its sibling. Keep the structured branch intact instead of applying branch-hoisting
+        // rewrites whose dominance assumptions are not valid for that incomplete trace.
+        if matches!(condition, Expr::Bool(true) | Expr::Bool(false)) {
+            output.push(Statement::IfElse { condition, then_body, else_body });
+            continue;
+        }
 
         // Dynamic-array loops commonly expose the zero-length return arm while executor jump
         // deduplication truncates the non-empty arm. The same ABI encoding is the loop's eventual
@@ -161,7 +260,7 @@ fn simplify_block(block: Vec<Statement>) -> Vec<Statement> {
         if else_body.is_empty() && zero_length_guard(&condition) {
             if let Some(statement) = abi_encoded_return(&then_body) {
                 output.push(statement);
-                continue
+                continue;
             }
         }
 
@@ -232,6 +331,9 @@ pub(crate) fn structure_control_flow(
     function: &mut AnalyzedFunction,
     _: &mut PostprocessorState,
 ) -> Result<(), Error> {
+    // Do not simplify the complete tree here: trace deduplication can leave incomplete branch
+    // alternatives, and normalizing a condition before recovering those alternatives can change
+    // their apparent structure.
     let flat = function.statements.clone();
     let mut cursor = 0;
     function.statements =
@@ -317,18 +419,69 @@ mod tests {
     }
 
     #[test]
-    fn removes_compiler_calldata_guard() {
+    fn removes_strict_calldata_validity_checks() {
         let mut function = AnalyzedFunction::new("00000000", false);
+        let offset =
+            Expr::binary(BinaryOp::Add, Expr::Literal(U256::from(4)), Expr::identifier("arg0"));
         function.statements = vec![Statement::Require {
             condition: Expr::binary(
-                crate::core::ir::BinaryOp::Ge,
-                Expr::identifier("msg.data.length"),
-                Expr::Literal(U256::from(36)),
+                BinaryOp::Ge,
+                Expr::binary(BinaryOp::Sub, Expr::identifier("msg.data.length"), offset),
+                Expr::Literal(U256::from(32)),
             ),
             reason: None,
         }];
         structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
         assert!(function.statements.is_empty());
+    }
+
+    #[test]
+    fn removes_calldata_validity_conjunct_but_preserves_contract_condition() {
+        let validity = Expr::binary(
+            BinaryOp::Ge,
+            Expr::binary(
+                BinaryOp::Sub,
+                Expr::identifier("msg.data.length"),
+                Expr::Literal(U256::from(4)),
+            ),
+            Expr::Literal(U256::from(32)),
+        );
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If {
+                condition: Expr::binary(
+                    BinaryOp::LogicalAnd,
+                    validity,
+                    Expr::identifier("authorized"),
+                ),
+            },
+            Statement::Return(Expr::Bool(true)),
+            Statement::Else,
+            Statement::Revert(None),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(matches!(
+            function.statements.as_slice(),
+            [Statement::Require { condition: Expr::Identifier(name), .. }, Statement::Return(Expr::Bool(true))]
+                if name == "authorized"
+        ));
+    }
+
+    #[test]
+    fn preserves_non_abi_calldata_length_checks() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        let guard = Statement::Require {
+            condition: Expr::binary(
+                BinaryOp::Gt,
+                Expr::identifier("msg.data.length"),
+                Expr::identifier("minimumPayloadLength"),
+            ),
+            reason: None,
+        };
+        function.statements = vec![guard.clone()];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert_eq!(function.statements, vec![guard]);
     }
 
     #[test]
@@ -374,6 +527,33 @@ mod tests {
         ];
         structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
         assert_eq!(function.statements[0].render(RenderTarget::Solidity), "require(!ok, \"bad\");");
+    }
+
+    #[test]
+    fn removes_require_true_after_expression_simplification() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements =
+            vec![Statement::Require { condition: Expr::Bool(true), reason: None }];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(function.statements.is_empty());
+    }
+
+    #[test]
+    fn keeps_constant_branches_intact_when_recovering_incomplete_traces() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::If { condition: Expr::Bool(false) },
+            Statement::Revert(Some(Expr::StringLiteral("unreachable".to_string()))),
+            Statement::Else,
+            Statement::Return(Expr::Bool(true)),
+            Statement::CloseBlock,
+        ];
+        structure_control_flow(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(matches!(
+            function.statements.as_slice(),
+            [Statement::IfElse { condition: Expr::Bool(false), then_body, else_body }]
+                if then_body.len() == 1 && else_body == &vec![Statement::Return(Expr::Bool(true))]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What changed? Why?

Added conservative, structured IR identity folding to clean tautological decompiler output without parsing rendered Solidity. The pass folds duplicate-safe bitwise AND/OR expressions and boolean conjunction identities, removes tautological `require(true)` guards, and removes proven ABI-calldata validity checks when they occur as standalone requirements or operands of a conjunction.

## Notes to reviewers

The implementation changes `crates/decompile/src/core/ir.rs` and `crates/decompile/src/utils/postprocessors/control_flow.rs`. Non-payable and external-call-success guard recognition matches structured `Expr` variants rather than rendered source text. ABI validity guards are matched only in canonical offset forms: `msg.data.length - offset >= required` and `offset < msg.data.length`, where offset arithmetic is derived from ABI offsets (selector offset `4` and/or calldata loads). The pass recursively removes only those proven operands from `&&` trees; arbitrary calldata-length conditions and all other conjuncts are retained. Duplicate folds exclude raw expressions, calls, storage/memory accesses, and other potentially observable reads.

## How has it been tested?

- Ran `cargo test -p heimdall-decompiler --lib` successfully (68 tests).
- Ran `rustup run nightly cargo fmt --check`.
- Decompiled `0x3E2a2BC69E5C22A8DA4056B413621D1820Eb493E` from `largest1k/` and compared it against a clean `main` worktree. Output remains 877 lines, falls from 31,921 to 31,831 bytes, and removes ABI-validity conjuncts while retaining the business conditions.