### PR TITLE
fix(decompile): finalize IR cleanup before lowering

### DIFF
--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -8,10 +8,11 @@ use crate::{
     interfaces::AnalyzedFunction,
     utils::postprocessors::{
         arithmetic_postprocessor, bitwise_mask_postprocessor, detect_string_storage_getter,
-        eliminate_dead_variables, inline_single_use_variables, memory_postprocessor,
-        normalize_typed_returns, storage_inference_postprocessor, storage_postprocessor,
-        structure_control_flow, transient_postprocessor, type_cleanup_postprocessor,
-        variable_postprocessor, IrFunctionPostprocessor, IrPostprocessor,
+        eliminate_dead_variables, finalize_function, inline_single_use_variables,
+        memory_postprocessor, normalize_typed_returns, storage_inference_postprocessor,
+        storage_postprocessor, structure_control_flow, transient_postprocessor,
+        type_cleanup_postprocessor, variable_postprocessor, IrFunctionPostprocessor,
+        IrPostprocessor,
     },
     Error,
 };
@@ -240,6 +241,9 @@ impl PostprocessOrchestrator {
                 self.ir_function_passes.push(inline_single_use_variables);
                 self.ir_function_passes.push(eliminate_dead_variables);
                 self.ir_function_passes.push(structure_control_flow);
+                // Inlining, dead-code removal, and control-flow reconstruction expose fresh
+                // simplification and type-cleanup opportunities before lowering.
+                self.ir_function_passes.push(finalize_function);
             }
             AnalyzerType::Yul => {}
             _ => {}

--- a/crates/decompile/src/utils/postprocessors/memory.rs
+++ b/crates/decompile/src/utils/postprocessors/memory.rs
@@ -51,7 +51,10 @@ pub(crate) fn memory_postprocessor(
     // Track conditional nesting depth so we don't record block-local variables.
     match statement {
         Statement::If { .. } => state.conditional_depth += 1,
-        Statement::Else | Statement::CloseBlock => {
+        // `Else` remains inside the same lexical conditional. Only its matching closing
+        // marker exits the scope; otherwise assignments from an else arm leak into the
+        // function-wide substitution state as though they were unconditional.
+        Statement::CloseBlock => {
             state.conditional_depth = state.conditional_depth.saturating_sub(1);
         }
         _ => {}

--- a/crates/decompile/src/utils/postprocessors/mod.rs
+++ b/crates/decompile/src/utils/postprocessors/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use memory::memory_postprocessor;
 pub(crate) use storage::storage_postprocessor;
 pub(crate) use storage_inference::storage_inference_postprocessor;
 pub(crate) use transient::transient_postprocessor;
-pub(crate) use types::{normalize_typed_returns, type_cleanup_postprocessor};
+pub(crate) use types::{finalize_function, normalize_typed_returns, type_cleanup_postprocessor};
 pub(crate) use variable::variable_postprocessor;
 
 /// A structured IR postprocessor function signature.

--- a/crates/decompile/src/utils/postprocessors/storage.rs
+++ b/crates/decompile/src/utils/postprocessors/storage.rs
@@ -132,7 +132,9 @@ pub(crate) fn storage_postprocessor(
     // Track conditional nesting depth so we don't record block-local variables.
     match statement {
         Statement::If { .. } => state.conditional_depth += 1,
-        Statement::Else | Statement::CloseBlock => {
+        // `Else` is a sibling arm, not the end of the conditional scope. Keep it scoped so
+        // branch-local storage assignments cannot be recorded as unconditional aliases.
+        Statement::CloseBlock => {
             state.conditional_depth = state.conditional_depth.saturating_sub(1);
         }
         _ => {}

--- a/crates/decompile/src/utils/postprocessors/transient.rs
+++ b/crates/decompile/src/utils/postprocessors/transient.rs
@@ -43,7 +43,9 @@ pub(crate) fn transient_postprocessor(
     // Track conditional nesting depth so we don't record block-local variables.
     match statement {
         Statement::If { .. } => state.conditional_depth += 1,
-        Statement::Else | Statement::CloseBlock => {
+        // An else arm is still conditional. Keep its assignments out of the shared alias map
+        // until the matching closing marker exits the lexical scope.
+        Statement::CloseBlock => {
             state.conditional_depth = state.conditional_depth.saturating_sub(1);
         }
         _ => {}

--- a/crates/decompile/src/utils/postprocessors/types.rs
+++ b/crates/decompile/src/utils/postprocessors/types.rs
@@ -119,6 +119,52 @@ pub(crate) fn type_cleanup_postprocessor(
     Ok(())
 }
 
+/// Canonicalizes a fully transformed function immediately before source lowering.
+///
+/// Function-wide passes can expose redundant casts, constant conditions, and no-op statements
+/// after the statement-local cleanup phase has already run. Revisit the structured tree here so
+/// those opportunities are handled without ever parsing rendered Solidity.
+pub(crate) fn finalize_function(
+    function: &mut AnalyzedFunction,
+    state: &mut PostprocessorState,
+) -> Result<(), Error> {
+    fn finalize_block(
+        statements: Vec<Statement>,
+        state: &mut PostprocessorState,
+    ) -> Result<Vec<Statement>, Error> {
+        let mut output = Vec::with_capacity(statements.len());
+        for mut statement in statements {
+            // Simplify before and after type cleanup: the latter can remove a cast and thereby
+            // expose an identity in its parent expression.
+            statement = statement.simplify();
+            type_cleanup_postprocessor(&mut statement, state)?;
+            statement = statement.simplify();
+
+            match statement {
+                Statement::Noop => {}
+                Statement::Require { condition: Expr::Bool(true), .. } => {}
+                Statement::IfElse { condition, then_body, else_body } => {
+                    let then_body = finalize_block(then_body, state)?;
+                    let else_body = finalize_block(else_body, state)?;
+                    match condition {
+                        Expr::Bool(true) => output.extend(then_body),
+                        Expr::Bool(false) => output.extend(else_body),
+                        _ if then_body.is_empty() && else_body.is_empty() => {}
+                        condition => {
+                            output.push(Statement::IfElse { condition, then_body, else_body })
+                        }
+                    }
+                }
+                statement => output.push(statement),
+            }
+        }
+        Ok(output)
+    }
+
+    function.statements = finalize_block(std::mem::take(&mut function.statements), state)?;
+    Ok(())
+}
+
 /// Rewrites literal return values using the function's inferred return type.
 pub(crate) fn normalize_typed_returns(
     function: &mut AnalyzedFunction,
@@ -194,5 +240,27 @@ mod tests {
         state.memory_type_map.insert("arg0".to_string(), "uint256".to_string());
         type_cleanup_postprocessor(&mut statement, &mut state).unwrap();
         assert_eq!(statement.render(RenderTarget::Solidity), "return uint8(arg0);");
+    }
+
+    #[test]
+    fn finalization_removes_post_inline_redundant_cast_and_constant_branches() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::Require { condition: Expr::Bool(true), reason: None },
+            Statement::IfElse {
+                condition: Expr::Bool(false),
+                then_body: vec![Statement::Return(Expr::Literal(alloy::primitives::U256::ZERO))],
+                else_body: vec![Statement::Return(Expr::Cast {
+                    ty: "address".to_string(),
+                    value: Box::new(Expr::identifier("arg0")),
+                })],
+            },
+        ];
+        let mut state = PostprocessorState::default();
+        state.memory_type_map.insert("arg0".to_string(), "address".to_string());
+
+        finalize_function(&mut function, &mut state).unwrap();
+
+        assert_eq!(function.statements, vec![Statement::Return(Expr::identifier("arg0"))]);
     }
 }

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -18,7 +18,9 @@ pub(crate) fn variable_postprocessor(
     // Track conditional nesting depth so we don't record block-local variables.
     match statement {
         Statement::If { .. } => state.conditional_depth += 1,
-        Statement::Else | Statement::CloseBlock => {
+        // Both arms share the conditional scope. Decrementing at `Else` incorrectly lets
+        // aliases produced by the else arm escape into later unconditional statements.
+        Statement::CloseBlock => {
             state.conditional_depth = state.conditional_depth.saturating_sub(1);
         }
         _ => {}
@@ -121,5 +123,26 @@ mod tests {
         );
         variable_postprocessor(&mut statement, &mut state).unwrap();
         assert_eq!(statement.render(RenderTarget::Solidity), "return var_a * 0x02;");
+    }
+
+    #[test]
+    fn does_not_promote_else_assignment_to_function_scope() {
+        let mut state = PostprocessorState::default();
+        let mut statements = vec![
+            Statement::If { condition: Expr::identifier("condition") },
+            Statement::Else,
+            Statement::Assign {
+                target: Expr::identifier("var_a"),
+                value: Expr::identifier("arg0"),
+            },
+            Statement::CloseBlock,
+        ];
+
+        for statement in &mut statements {
+            variable_postprocessor(statement, &mut state).unwrap();
+        }
+
+        assert!(!state.variable_map.contains_key(&Expr::identifier("var_a")));
+        assert_eq!(state.conditional_depth, 0);
     }
 }

--- a/crates/vm/src/core/vm/core.rs
+++ b/crates/vm/src/core/vm/core.rs
@@ -1399,10 +1399,9 @@ mod tests {
         let mut vm = new_test_vm("0x60fe56");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(
-            U256::from(vm.instruction),
-            U256::from_str("0xff").expect("failed to parse hex")
-        );
+        // EVM destinations must point at an in-range JUMPDEST; do not advance an invalid
+        // symbolic destination, which can overflow the program counter.
+        assert_eq!(vm.exitcode, 790);
     }
 
     #[test]
@@ -1410,10 +1409,7 @@ mod tests {
         let mut vm = new_test_vm("0x600160fe57");
         vm.execute().expect("execution failed!");
 
-        assert_eq!(
-            U256::from(vm.instruction),
-            U256::from_str("0xff").expect("failed to parse hex")
-        );
+        assert_eq!(vm.exitcode, 790);
 
         let mut vm = new_test_vm("0x600060fe5758");
         vm.execute().expect("execution failed!");

--- a/crates/vm/src/core/vm/handlers/control.rs
+++ b/crates/vm/src/core/vm/handlers/control.rs
@@ -35,14 +35,9 @@ pub fn jump(
     // Safely convert U256 to u128
     let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
-    // Check if JUMPDEST is valid and throw with 790 if not (invalid jump destination)
-    if (pc <=
-        vm.bytecode
-            .len()
-            .try_into()
-            .expect("impossible case: bytecode is larger than u128::MAX")) &&
-        (vm.bytecode[pc as usize] != opcodes::JUMPDEST)
-    {
+    // A destination outside the bytecode (including an unrepresentable U256 that was
+    // saturated above) is invalid. Check the bound before indexing or incrementing it.
+    if pc >= vm.bytecode.len() as u128 || vm.bytecode[pc as usize] != opcodes::JUMPDEST {
         vm.exit(790, Vec::new());
         return Some(Instruction {
             instruction: last_instruction,
@@ -72,15 +67,8 @@ pub fn jumpi(
     let pc: u128 = pc.try_into().unwrap_or(u128::MAX);
 
     if !condition.is_zero() {
-        // Check if JUMPDEST is valid and throw with 790 if not (invalid jump
-        // destination)
-        if (pc <
-            vm.bytecode
-                .len()
-                .try_into()
-                .expect("impossible case: bytecode is larger than u128::MAX")) &&
-            (vm.bytecode[pc as usize] != opcodes::JUMPDEST)
-        {
+        // Check bounds before indexing or incrementing an invalid symbolic destination.
+        if pc >= vm.bytecode.len() as u128 || vm.bytecode[pc as usize] != opcodes::JUMPDEST {
             vm.exit(790, Vec::new());
             return Some(Instruction {
                 instruction: last_instruction,


### PR DESCRIPTION
## What changed? Why?

Adds a final structured-IR canonicalization pass after all existing function-wide decompiler transforms. This removes no-op statements, tautological `require(true)` guards, empty or constant branches, and casts made redundant by inlining or control-flow reconstruction. It also fixes conditional-depth tracking so `else` arms do not publish branch-local aliases as unconditional memory, storage, transient-storage, or variable state.

While validating the live-contract corpus, an invalid symbolic JUMP destination could overflow the VM program counter. Invalid JUMP and taken-JUMPI destinations now terminate with the existing invalid-jump exit code before indexing or incrementing the PC.

## Notes to reviewers

- `crates/decompile/src/utils/postprocessors/types.rs`: final IR canonicalization and regression coverage.
- `crates/decompile/src/core/postprocess.rs`: runs canonicalization immediately before lowering.
- Memory, storage, transient, and variable postprocessors retain conditional scope through `Else`.
- VM JUMP/JUMPI bounds checks now reject out-of-range destinations safely.
- Live-contract output comparison showed 21 fewer Solidity lines for `0x05bfA9157E92690b179033cA2f6dd1e86B25Ea4D`, including 17 removed tautological guards.

## How has it been tested?

- `cargo +nightly fmt --check --all`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --all-features -- --allow clippy::new_without_default --allow clippy::redundant_field_names --allow clippy::too_many_arguments --allow clippy::format_in_format_args --allow clippy::should_implement_trait`
- `cargo nextest run --no-fail-fast --release` — 466 passed, 5 skipped (one pre-existing flaky config test passed on retry).
- `cargo test --workspace --doc`
- `cargo test -p heimdall-vm --lib`
- Decompiled live bytecode from the checked-in `largest1k` corpus; the ignored heavy test processed 993 contracts before the local 20-minute command limit, then the remaining seven contracts completed successfully when run individually.
