### PR TITLE
fix(decompile): preserve inlined operand values

### DIFF
--- a/crates/decompile/src/utils/postprocessors/inline.rs
+++ b/crates/decompile/src/utils/postprocessors/inline.rs
@@ -96,6 +96,13 @@ pub(crate) fn inline_single_use_variables(
                 assignment(&function.statements[idx]).is_some_and(|(name, _)| name == variable)
             })
             .unwrap_or(function.statements.len());
+        // Substitution is only sound while every identifier captured by the value retains the
+        // value it had at the original assignment.
+        if function.statements[assignment_idx + 1..end].iter().any(|statement| {
+            assignment(statement).is_some_and(|(name, _)| identifiers.contains(name))
+        }) {
+            continue
+        }
         let uses = function.statements[assignment_idx + 1..end]
             .iter()
             .map(|statement| usage_count(statement, &variable))
@@ -163,6 +170,32 @@ mod tests {
         assert_eq!(
             function.statements[1].render(RenderTarget::Solidity),
             "return blockhash(arg0);"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_when_operand_is_reassigned_before_use() {
+        let mut function = AnalyzedFunction::new("00000000", false);
+        function.statements = vec![
+            Statement::Assign {
+                target: Expr::identifier("var_a"),
+                value: Expr::binary(
+                    crate::core::ir::BinaryOp::Add,
+                    Expr::identifier("var_b"),
+                    Expr::Literal(U256::from(1)),
+                ),
+            },
+            Statement::Assign {
+                target: Expr::identifier("var_b"),
+                value: Expr::Literal(U256::from(99)),
+            },
+            Statement::Return(Expr::identifier("var_a")),
+        ];
+        inline_single_use_variables(&mut function, &mut PostprocessorState::default()).unwrap();
+        assert!(!matches!(function.statements[0], Statement::Noop));
+        assert_eq!(
+            function.statements[2].render(RenderTarget::Solidity),
+            "return var_a;"
         );
     }
 

--- a/crates/decompile/src/utils/postprocessors/inline.rs
+++ b/crates/decompile/src/utils/postprocessors/inline.rs
@@ -193,10 +193,7 @@ mod tests {
         ];
         inline_single_use_variables(&mut function, &mut PostprocessorState::default()).unwrap();
         assert!(!matches!(function.statements[0], Statement::Noop));
-        assert_eq!(
-            function.statements[2].render(RenderTarget::Solidity),
-            "return var_a;"
-        );
+        assert_eq!(function.statements[2].render(RenderTarget::Solidity), "return var_a;");
     }
 
     #[test]


### PR DESCRIPTION
## What changed? Why?

Fixes #724.

`inline_single_use_variables` now rejects an inline candidate when any identifier captured by its value is reassigned before the target variable's next assignment. This preserves the value at the original assignment instead of accidentally evaluating the operand's newer value at the substitution site.

The issue was confirmed with a regression test: before the fix, `var_a = var_b + 1; var_b = 99; return var_a;` was incorrectly rendered as `return var_b + 1;` after removing the `var_a` assignment.

## Notes to reviewers

- Updated `crates/decompile/src/utils/postprocessors/inline.rs`.
- Added a focused regression test for operand reassignment before the target's sole use.
- The secondary nested-mapping observation in #724 is independent and intentionally not included in this focused fix.

## How has it been tested?

- `cargo test -p heimdall-decompiler` (69 passed)
- Live Ethereum contract decompilation through `https://cloudflare-eth.com`:
  - `test_decompile_edge_case_u256_conversion_overflow_1` passed (`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`)
  - `test_decompile_edge_case_u256_conversion_overflow_2` passed (`0x5141b82f5ffda4c6fe1e372978f1c5427640a190`)
- `git diff --check`

Additional baseline triage: the WETH and precompile live tests currently miss existing expected-source assertions on unchanged `main`, and the live vec-overflow test panics in VM stack handling. Those failures reproduce without this patch and are unrelated to #724.
