### PR TITLE
ci: make AI evaluation suite opt-in

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
+      request_comment_id: ${{ steps.pr.outputs.request_comment_id }}
       same_repository: ${{ steps.pr.outputs.same_repository }}
       trusted_requester: ${{ steps.pr.outputs.trusted_requester }}
     steps:
@@ -72,6 +73,7 @@ jobs:
             });
 
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('request_comment_id', context.payload.comment.id);
             core.setOutput('same_repository', String(pr.head.repo?.full_name === context.repo.owner + '/' + context.repo.repo));
             core.setOutput('trusted_requester', String(['admin', 'maintain', 'write'].includes(permission.permission)));
 
@@ -84,6 +86,26 @@ jobs:
       needs.resolve-pr.outputs.trusted_requester == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Show evaluation progress on PR
+        uses: actions/github-script@v7
+        env:
+          EVAL_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+        with:
+          script: |
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ needs.resolve-pr.outputs.request_comment_id }},
+              body: [
+                '<!-- heimdall-eval-request -->',
+                '## AI Evaluation Suite',
+                '',
+                `:hourglass_flowing_sand: Running the [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval) AI evaluation suite for ${process.env.EVAL_SHA}.`,
+                '',
+                '- [x] Run AI Evaluation Suite',
+              ].join('\n'),
+            });
+
       - name: Checkout heimdall-rs (PR branch)
         uses: actions/checkout@v4
         with:
@@ -127,6 +149,8 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
+        env:
+          EVAL_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
         with:
           script: |
             const fs = require('fs');
@@ -199,38 +223,45 @@ jobs:
               detailsBlock = `\n\n<details>\n<summary>:warning: ${lowScoringEntries.length} eval(s) scoring &lt;70%</summary>\n\n${detailsSections.join('\n---\n\n')}\n</details>`;
             }
 
-            const body = `## ${icon} Eval Report for ${context.sha}
+            const body = [
+              '<!-- heimdall-eval-request -->',
+              `## ${icon} AI Evaluation Suite for ${process.env.EVAL_SHA}`,
+              '',
+              'Completed [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval).',
+              '',
+              '| Test Case | CFG | Decompilation |',
+              '|-----------|-----|---------------|',
+              tableRows,
+              `| **Average** | **${avgCfg}** | **${avgDecomp}** |${detailsBlock}`,
+              '',
+              '- [x] Run AI Evaluation Suite',
+            ].join('\n');
 
-            | Test Case | CFG | Decompilation |
-            |-----------|-----|---------------|
-            ${tableRows}
-            | **Average** | **${avgCfg}** | **${avgDecomp}** |${detailsBlock}`;
-
-            // Delete old eval comments
-            const { data: comments } = await github.rest.issues.listComments({
+            // Replace the request comment so the PR has one live evaluation status.
+            await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              comment_id: ${{ needs.resolve-pr.outputs.request_comment_id }},
+              body,
             });
 
-            const evalComments = comments.filter(
-              c => c.user.login === 'github-actions[bot]' && c.body.includes('Eval Report for')
-            );
-
-            for (const comment of evalComments) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: comment.id,
-              });
-            }
-
-            // Create new comment
-            await github.rest.issues.createComment({
+      - name: Show evaluation failure on PR
+        if: ${{ failure() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
+              comment_id: ${{ needs.resolve-pr.outputs.request_comment_id }},
+              body: [
+                '<!-- heimdall-eval-request -->',
+                '## :x: AI Evaluation Suite',
+                '',
+                `The [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval) run failed. See [the workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+                '',
+                '- [x] Run AI Evaluation Suite',
+              ].join('\n'),
             });
 
       - name: Upload eval artifacts

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -36,7 +36,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `${marker}\n## AI Evaluation Suite\n\nTo run the AI evaluation suite, add the checkbox below to a comment **you author** on this PR, then check it. Checking another user's comment is not supported by GitHub.\n\n- [ ] Run AI Evaluation Suite`,
+                body: `${marker}\n## AI Evaluation Suite\n\nCheck the box below to run the AI evaluation suite.\n\n- [ ] Run AI Evaluation Suite`,
               });
             }
 
@@ -45,16 +45,15 @@ jobs:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
+      contains(github.event.comment.body, '<!-- heimdall-eval-request -->') &&
       contains(github.event.comment.body, '- [x] Run AI Evaluation Suite') &&
       (github.event.action == 'created' ||
-       !contains(github.event.changes.body.from, '- [x] Run AI Evaluation Suite')) &&
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'MEMBER' ||
-       github.event.comment.author_association == 'COLLABORATOR')
+       !contains(github.event.changes.body.from, '- [x] Run AI Evaluation Suite'))
     runs-on: ubuntu-latest
     outputs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
       same_repository: ${{ steps.pr.outputs.same_repository }}
+      trusted_requester: ${{ steps.pr.outputs.trusted_requester }}
     steps:
       - name: Resolve pull request head
         id: pr
@@ -66,15 +65,23 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.issue.number,
             });
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('same_repository', String(pr.head.repo?.full_name === context.repo.owner + '/' + context.repo.repo));
+            core.setOutput('trusted_requester', String(['admin', 'maintain', 'write'].includes(permission.permission)));
 
   eval:
     name: run eval
     needs: resolve-pr
     if: >-
       needs.resolve-pr.result == 'success' &&
-      needs.resolve-pr.outputs.same_repository == 'true'
+      needs.resolve-pr.outputs.same_repository == 'true' &&
+      needs.resolve-pr.outputs.trusted_requester == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout heimdall-rs (PR branch)

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -36,7 +36,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `${marker}\n## AI Evaluation Suite\n\nCheck the box below to run the AI evaluation suite.\n\n- [ ] Run AI Evaluation Suite`,
+                body: `${marker}\n## AI Evaluation Suite\n\nCheck the box below to run the [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval) AI evaluation suite.\n\n- [ ] Run AI Evaluation Suite`,
               });
             }
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -2,9 +2,12 @@ name: eval
 
 on:
   pull_request:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created, edited]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -12,12 +15,72 @@ permissions:
   pull-requests: write
 
 jobs:
+  request-eval:
+    name: Post evaluation request instructions
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment with evaluation instructions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- heimdall-eval-request -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            if (!comments.some(comment => comment.body.includes(marker))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `${marker}\n## AI Evaluation Suite\n\nTo run the AI evaluation suite, add the checkbox below to a comment **you author** on this PR, then check it. Checking another user's comment is not supported by GitHub.\n\n- [ ] Run AI Evaluation Suite`,
+              });
+            }
+
+  resolve-pr:
+    name: Validate evaluation request
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '- [x] Run AI Evaluation Suite') &&
+      (github.event.action == 'created' ||
+       !contains(github.event.changes.body.from, '- [x] Run AI Evaluation Suite')) &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      same_repository: ${{ steps.pr.outputs.same_repository }}
+    steps:
+      - name: Resolve pull request head
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('same_repository', String(pr.head.repo?.full_name === context.repo.owner + '/' + context.repo.repo));
+
   eval:
     name: run eval
+    needs: resolve-pr
+    if: >-
+      needs.resolve-pr.result == 'success' &&
+      needs.resolve-pr.outputs.same_repository == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout heimdall-rs (PR branch)
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
 
       - name: Checkout heimdall-eval
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed? Why?

The AI evaluation workflow is now opt-in. On pull request open or reopen, it posts a task-list comment linking to [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval). A repository collaborator with write, maintain, or admin permission can check `Run AI Evaluation Suite` to run the suite against the PR head. The request comment is edited to show that the suite is running, then replaced with the completed evaluation report (or a failure status and workflow link). This avoids consuming AI evaluation resources for every pushed commit.

## Notes to reviewers

The workflow listens for edits to the marked bot comment, validates the actor who checked the task list, and rejects fork PRs before code is evaluated with repository secrets. GitHub loads `issue_comment` workflows from the default branch, so the checkbox trigger becomes active after this workflow is merged.

## How has it been tested?

- Ran `git diff --check`.
- Parsed `.github/workflows/eval.yml` using Ruby YAML.
- Confirmed the PR-open workflow posts the evaluation request comment.
- The checkbox event cannot be exercised from this PR because `issue_comment` workflow definitions are read from `main`; it must be merged before GitHub can dispatch this new trigger.