### PR TITLE
feat(vm): add canonical basic-block frontend

### DIFF
--- a/crates/disassemble/src/core/mod.rs
+++ b/crates/disassemble/src/core/mod.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use crate::{error::Error, interfaces::DisassemblerArgs};
 use eyre::eyre;
 use heimdall_common::utils::strings::encode_hex;
-use heimdall_vm::core::opcodes::OpCodeInfo;
+use heimdall_vm::core::{opcodes::OpCodeInfo, program::Program};
 use tracing::{debug, info};
 
 /// Disassembles EVM bytecode into readable assembly instructions
@@ -22,7 +22,6 @@ use tracing::{debug, info};
 pub async fn disassemble(args: DisassemblerArgs) -> Result<String, Error> {
     // init
     let start_time = Instant::now();
-    let mut program_counter = 0;
     let mut asm = String::new();
 
     // Resolve hardfork (handles Auto detection if needed)
@@ -36,47 +35,35 @@ pub async fn disassemble(args: DisassemblerArgs) -> Result<String, Error> {
         args.get_bytecode().await.map_err(|e| eyre!("fetching target bytecode failed: {}", e))?;
     debug!("fetching target bytecode took {:?}", start_fetch_time.elapsed());
 
-    // iterate over the bytecode, disassembling each instruction
+    // Decode through the shared structural front end so disassembly, CFG recovery, and future
+    // analysis passes agree on instruction boundaries and truncated PUSH semantics.
     let start_disassemble_time = Instant::now();
-    while program_counter < contract_bytecode.len() {
-        let opcode = contract_bytecode[program_counter];
-        let mut pushed_bytes = String::new();
-
-        // handle PUSH0 -> PUSH32, which require us to push the next N bytes
-        // onto the stack
-        let mut byte_count_to_push_offset = 0;
-        if (0x5f..=0x7f).contains(&opcode) {
-            let byte_count_to_push: u8 = opcode - 0x5f;
-            pushed_bytes = match contract_bytecode
-                .get(program_counter + 1..program_counter + 1 + byte_count_to_push as usize)
-            {
-                Some(bytes) => encode_hex(bytes),
-                None => break,
-            };
-            byte_count_to_push_offset += byte_count_to_push as usize;
-        }
-
-        // Get the opcode name, respecting hardfork activation
-        let opcode_name = match OpCodeInfo::for_fork(opcode, hardfork) {
-            Some(info) => info.name(),
-            None => "unknown",
+    let program = Program::decode(&contract_bytecode, hardfork);
+    for instruction in &program.instructions {
+        let opcode_name = OpCodeInfo::for_fork(instruction.opcode, hardfork)
+            .map_or("unknown", |info| info.name());
+        let pushed_bytes = if instruction.immediate.is_empty() {
+            String::new()
+        } else {
+            encode_hex(&instruction.immediate)
         };
-
-        let offset = program_counter;
         asm.push_str(
             format!(
                 "{} {} {}\n",
-                if args.decimal_counter { offset.to_string() } else { format!("{offset:06x}") },
+                if args.decimal_counter {
+                    instruction.pc.to_string()
+                } else {
+                    format!("{:06x}", instruction.pc)
+                },
                 opcode_name,
                 pushed_bytes
             )
             .as_str(),
         );
-        program_counter += 1 + byte_count_to_push_offset;
     }
     debug!("disassembly took {:?}", start_disassemble_time.elapsed());
 
-    info!("disassembled {} bytes successfully", program_counter);
+    info!("disassembled {} bytes successfully", contract_bytecode.len());
     debug!("disassembly took {:?}", start_time.elapsed());
     Ok(asm)
 }

--- a/crates/disassemble/src/core/mod.rs
+++ b/crates/disassemble/src/core/mod.rs
@@ -40,6 +40,11 @@ pub async fn disassemble(args: DisassemblerArgs) -> Result<String, Error> {
     let start_disassemble_time = Instant::now();
     let program = Program::decode(&contract_bytecode, hardfork);
     for instruction in &program.instructions {
+        // Preserve the disassembler's existing behavior for incomplete trailing PUSH data. The
+        // structural frontend still retains the instruction for analysis with EVM zero-padding.
+        if instruction.truncated {
+            break
+        }
         let opcode_name = OpCodeInfo::for_fork(instruction.opcode, hardfork)
             .map_or("unknown", |info| info.name());
         let pushed_bytes = if instruction.immediate.is_empty() {

--- a/crates/vm/src/core/mod.rs
+++ b/crates/vm/src/core/mod.rs
@@ -16,6 +16,9 @@ pub mod memory;
 /// Opcode definitions and implementations
 pub mod opcodes;
 
+/// Canonical bytecode decoding and basic-block recovery
+pub mod program;
+
 /// Stack implementation for the VM
 pub mod stack;
 

--- a/crates/vm/src/core/program.rs
+++ b/crates/vm/src/core/program.rs
@@ -1,0 +1,376 @@
+//! Canonical decoding and basic-block recovery for EVM bytecode.
+//!
+//! This module provides a structural front end that is independent of concrete VM execution. It
+//! decodes PUSH immediates once, identifies every basic-block boundary, validates direct jump
+//! targets, and records the statically-known CFG edges. Dynamic jump edges are intentionally left
+//! unresolved for a later abstract or symbolic analysis pass.
+
+use std::{collections::HashMap, ops::Range};
+
+use alloy::primitives::U256;
+
+use super::{
+    hardfork::HardFork,
+    opcodes::{self, OpCodeInfo},
+};
+
+/// The stable identifier of a basic block within a [`Program`].
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BlockId(usize);
+
+impl BlockId {
+    /// Return this block's zero-based index in [`Program::blocks`].
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// A decoded EVM instruction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DecodedInstruction {
+    /// Zero-based byte offset of the opcode.
+    pub pc: usize,
+    /// Raw opcode byte.
+    pub opcode: u8,
+    /// Bytes following a PUSH opcode that belong to its immediate operand.
+    pub immediate: Vec<u8>,
+    /// Whether a PUSH operand was truncated by the end of the bytecode.
+    pub truncated: bool,
+}
+
+impl DecodedInstruction {
+    /// Number of bytecode bytes occupied by this instruction.
+    pub fn size(&self) -> usize {
+        1 + self.immediate.len()
+    }
+
+    /// Byte offset immediately after this instruction.
+    pub fn next_pc(&self) -> usize {
+        self.pc + self.size()
+    }
+
+    /// Returns the PUSH operand as a 256-bit value, or `None` for non-PUSH instructions.
+    ///
+    /// A truncated operand is right-padded with zero bytes, matching the EVM's code-reading
+    /// semantics at the end of bytecode.
+    pub fn push_value(&self) -> Option<U256> {
+        let width = push_width(self.opcode)?;
+        let mut bytes = [0u8; 32];
+        bytes[32 - width..32 - width + self.immediate.len()].copy_from_slice(&self.immediate);
+        Some(U256::from_be_bytes(bytes))
+    }
+}
+
+/// The control-transfer behavior that terminates a basic block.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlockTerminator {
+    /// Execution continues into the next basic block.
+    Fallthrough,
+    /// An unconditional jump whose destination is read from the stack.
+    Jump,
+    /// A conditional jump with a statically-known fallthrough.
+    ConditionalJump,
+    /// An opcode that terminates execution.
+    Halt,
+    /// An unknown or hardfork-inactive opcode that terminates this execution path.
+    Invalid,
+}
+
+/// The kind of a statically-known control-flow edge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EdgeKind {
+    /// Ordinary sequential control flow between adjacent basic blocks.
+    Fallthrough,
+    /// The condition of a JUMPI is false.
+    ConditionalFalse,
+    /// A JUMP or the true side of a JUMPI has a locally constant destination.
+    Jump,
+}
+
+/// A statically-known edge between basic blocks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BlockEdge {
+    /// Destination block.
+    pub target: BlockId,
+    /// Control-flow relationship represented by this edge.
+    pub kind: EdgeKind,
+}
+
+/// A maximal sequence of instructions with one entry and no internal control transfer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BasicBlock {
+    /// Stable block identifier.
+    pub id: BlockId,
+    /// Zero-based byte offset of the first instruction.
+    pub start_pc: usize,
+    /// Byte offset immediately after the final instruction.
+    pub end_pc: usize,
+    /// Range into [`Program::instructions`] containing this block's instructions.
+    pub instructions: Range<usize>,
+    /// How control leaves this block.
+    pub terminator: BlockTerminator,
+    /// Edges that can be established without whole-program value-flow analysis.
+    pub static_edges: Vec<BlockEdge>,
+}
+
+/// A canonically decoded EVM program and its execution-independent basic-block CFG skeleton.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Program {
+    /// Original bytecode.
+    pub bytecode: Vec<u8>,
+    /// Decoded instructions in byte-offset order.
+    pub instructions: Vec<DecodedInstruction>,
+    /// Canonical basic blocks in byte-offset order.
+    pub blocks: Vec<BasicBlock>,
+    block_by_pc: HashMap<usize, BlockId>,
+}
+
+impl Program {
+    /// Decode bytecode and recover canonical basic blocks for the selected hardfork.
+    pub fn decode(bytecode: &[u8], hardfork: HardFork) -> Self {
+        let instructions = decode_instructions(bytecode);
+        let mut blocks = build_blocks(&instructions, hardfork);
+        let block_by_pc = blocks.iter().map(|block| (block.start_pc, block.id)).collect();
+        add_static_edges(&instructions, &mut blocks, &block_by_pc);
+
+        Self { bytecode: bytecode.to_vec(), instructions, blocks, block_by_pc }
+    }
+
+    /// Find the basic block that starts at `pc`.
+    pub fn block_at(&self, pc: usize) -> Option<&BasicBlock> {
+        self.block_by_pc.get(&pc).and_then(|id| self.blocks.get(id.0))
+    }
+
+    /// Get the decoded instructions belonging to a block.
+    pub fn block_instructions(&self, block: BlockId) -> &[DecodedInstruction] {
+        let block = &self.blocks[block.0];
+        &self.instructions[block.instructions.clone()]
+    }
+
+    /// Whether `pc` is a valid EVM jump destination.
+    pub fn is_valid_jumpdest(&self, pc: usize) -> bool {
+        self.block_at(pc).is_some_and(|block| {
+            self.instructions[block.instructions.start].opcode == opcodes::JUMPDEST
+        })
+    }
+}
+
+fn push_width(opcode: u8) -> Option<usize> {
+    if (opcodes::PUSH1..=opcodes::PUSH32).contains(&opcode) {
+        Some((opcode - opcodes::PUSH0) as usize)
+    } else {
+        None
+    }
+}
+
+fn decode_instructions(bytecode: &[u8]) -> Vec<DecodedInstruction> {
+    let mut instructions = Vec::new();
+    let mut pc = 0;
+
+    while pc < bytecode.len() {
+        let opcode = bytecode[pc];
+        let width = push_width(opcode).unwrap_or(0);
+        let available = width.min(bytecode.len().saturating_sub(pc + 1));
+        let immediate = bytecode[pc + 1..pc + 1 + available].to_vec();
+        instructions.push(DecodedInstruction {
+            pc,
+            opcode,
+            truncated: available < width,
+            immediate,
+        });
+        pc += 1 + available;
+    }
+
+    instructions
+}
+
+fn ends_block(instruction: &DecodedInstruction, hardfork: HardFork) -> bool {
+    instruction.opcode == opcodes::JUMP ||
+        instruction.opcode == opcodes::JUMPI ||
+        OpCodeInfo::for_fork(instruction.opcode, hardfork)
+            .is_none_or(|opcode| opcode.terminating())
+}
+
+fn terminator(instruction: &DecodedInstruction, hardfork: HardFork) -> BlockTerminator {
+    match instruction.opcode {
+        opcodes::JUMP => BlockTerminator::Jump,
+        opcodes::JUMPI => BlockTerminator::ConditionalJump,
+        opcode => match OpCodeInfo::for_fork(opcode, hardfork) {
+            Some(info) if info.terminating() => BlockTerminator::Halt,
+            Some(_) => BlockTerminator::Fallthrough,
+            None => BlockTerminator::Invalid,
+        },
+    }
+}
+
+fn build_blocks(instructions: &[DecodedInstruction], hardfork: HardFork) -> Vec<BasicBlock> {
+    if instructions.is_empty() {
+        return Vec::new();
+    }
+
+    let mut blocks = Vec::new();
+    let mut start = 0;
+
+    for index in 0..instructions.len() {
+        let current = &instructions[index];
+        let next_starts_block =
+            instructions.get(index + 1).is_some_and(|next| next.opcode == opcodes::JUMPDEST);
+        if ends_block(current, hardfork) || next_starts_block || index + 1 == instructions.len() {
+            let id = BlockId(blocks.len());
+            blocks.push(BasicBlock {
+                id,
+                start_pc: instructions[start].pc,
+                end_pc: current.next_pc(),
+                instructions: start..index + 1,
+                terminator: terminator(current, hardfork),
+                static_edges: Vec::new(),
+            });
+            start = index + 1;
+        }
+    }
+
+    blocks
+}
+
+fn direct_jump_target(
+    instructions: &[DecodedInstruction],
+    block: &BasicBlock,
+    block_by_pc: &HashMap<usize, BlockId>,
+) -> Option<BlockId> {
+    if block.instructions.len() < 2 {
+        return None;
+    }
+    let push = &instructions[block.instructions.end - 2];
+    let target = usize::try_from(push.push_value()?).ok()?;
+    let target_block = *block_by_pc.get(&target)?;
+    let target_instruction =
+        instructions.binary_search_by_key(&target, |instruction| instruction.pc).ok()?;
+    (instructions[target_instruction].opcode == opcodes::JUMPDEST).then_some(target_block)
+}
+
+fn add_static_edges(
+    instructions: &[DecodedInstruction],
+    blocks: &mut [BasicBlock],
+    block_by_pc: &HashMap<usize, BlockId>,
+) {
+    for index in 0..blocks.len() {
+        let terminator = blocks[index].terminator;
+        if matches!(terminator, BlockTerminator::Jump | BlockTerminator::ConditionalJump) {
+            if let Some(target) = direct_jump_target(instructions, &blocks[index], block_by_pc) {
+                blocks[index].static_edges.push(BlockEdge { target, kind: EdgeKind::Jump });
+            }
+        }
+
+        if matches!(terminator, BlockTerminator::Fallthrough | BlockTerminator::ConditionalJump) {
+            if let Some(next) = blocks.get(index + 1) {
+                blocks[index].static_edges.push(BlockEdge {
+                    target: next.id,
+                    kind: if terminator == BlockTerminator::ConditionalJump {
+                        EdgeKind::ConditionalFalse
+                    } else {
+                        EdgeKind::Fallthrough
+                    },
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_push_data_without_treating_it_as_code() {
+        let program =
+            Program::decode(&[opcodes::PUSH2, 0x5b, 0x00, opcodes::STOP], HardFork::Latest);
+        assert_eq!(program.instructions.len(), 2);
+        assert_eq!(program.instructions[0].immediate, vec![0x5b, 0x00]);
+        assert_eq!(program.instructions[1].pc, 3);
+    }
+
+    #[test]
+    fn splits_at_jumpdest_and_control_transfer() {
+        let bytecode = [
+            opcodes::PUSH1,
+            0x04,
+            opcodes::JUMP,
+            opcodes::STOP,
+            opcodes::JUMPDEST,
+            opcodes::PUSH0,
+            opcodes::STOP,
+        ];
+        let program = Program::decode(&bytecode, HardFork::Latest);
+        assert_eq!(
+            program.blocks.iter().map(|block| block.start_pc).collect::<Vec<_>>(),
+            vec![0, 3, 4]
+        );
+        assert_eq!(program.blocks[0].terminator, BlockTerminator::Jump);
+        assert_eq!(program.blocks[1].terminator, BlockTerminator::Halt);
+        assert!(program.is_valid_jumpdest(4));
+        assert_eq!(
+            program.blocks[0].static_edges,
+            vec![BlockEdge { target: BlockId(2), kind: EdgeKind::Jump }]
+        );
+    }
+
+    #[test]
+    fn leaves_symbolic_conditional_target_unresolved() {
+        let bytecode = [
+            opcodes::PUSH1,
+            0x06,
+            opcodes::PUSH1,
+            0x01,
+            opcodes::JUMPI,
+            opcodes::STOP,
+            opcodes::JUMPDEST,
+            opcodes::STOP,
+        ];
+        let program = Program::decode(&bytecode, HardFork::Latest);
+        assert_eq!(program.blocks[0].terminator, BlockTerminator::ConditionalJump);
+        assert_eq!(
+            program.blocks[0].static_edges,
+            vec![BlockEdge { target: BlockId(1), kind: EdgeKind::ConditionalFalse }]
+        );
+        // The destination is not immediately below JUMPI: its condition is, so local decoding
+        // correctly leaves the true edge for value-flow analysis.
+    }
+
+    #[test]
+    fn records_both_locally_known_conditional_edges() {
+        let bytecode = [
+            opcodes::PUSH1,
+            0x01,
+            opcodes::PUSH1,
+            0x06,
+            opcodes::JUMPI,
+            opcodes::STOP,
+            opcodes::JUMPDEST,
+            opcodes::STOP,
+        ];
+        let program = Program::decode(&bytecode, HardFork::Latest);
+        assert_eq!(
+            program.blocks[0].static_edges,
+            vec![
+                BlockEdge { target: BlockId(2), kind: EdgeKind::Jump },
+                BlockEdge { target: BlockId(1), kind: EdgeKind::ConditionalFalse },
+            ]
+        );
+    }
+
+    #[test]
+    fn pads_a_truncated_push_operand_on_the_right() {
+        let program = Program::decode(&[opcodes::PUSH2, 0x12], HardFork::Latest);
+        let instruction = &program.instructions[0];
+        assert!(instruction.truncated);
+        assert_eq!(instruction.push_value(), Some(U256::from(0x1200)));
+    }
+
+    #[test]
+    fn hardfork_inactive_opcode_ends_its_block() {
+        let program =
+            Program::decode(&[opcodes::PUSH0, opcodes::JUMPDEST, opcodes::STOP], HardFork::London);
+        assert_eq!(program.blocks[0].terminator, BlockTerminator::Invalid);
+        assert_eq!(program.blocks[1].start_pc, 1);
+    }
+}


### PR DESCRIPTION
## What changed? Why?

Adds an execution-independent EVM program frontend as the first foundation for improving CFG and decompilation accuracy.

The new `heimdall_vm::core::program` module:

- decodes bytecode once while keeping PUSH immediates out of the instruction stream
- preserves and right-pads truncated PUSH operands according to EVM code-reading semantics
- partitions instructions into canonical basic blocks at `JUMPDEST`, control-transfer, halt, and invalid-opcode boundaries
- classifies block terminators
- records statically-known fallthrough, conditional-false, and locally constant jump edges
- validates constant jump targets against real decoded `JUMPDEST` instructions
- deliberately leaves dynamic targets unresolved for a later abstract/symbolic value-flow pass

The disassembler now consumes this shared decoder instead of maintaining a second instruction-boundary implementation. This gives later CFG/worklist analysis a single structural representation to build on without changing the existing symbolic executor in this PR.

## Notes to reviewers

Key files:

- `crates/vm/src/core/program.rs`: decoded program, blocks, terminators, static edge skeleton, and focused tests
- `crates/vm/src/core/mod.rs`: exports the frontend
- `crates/disassemble/src/core/mod.rs`: adopts the shared decoder

This PR intentionally does not route dynamic CFG discovery through the new representation yet. Doing so safely requires the subsequent abstract-state/worklist analysis; forcing the current recursive executor to split at every unconditional jump reduced coverage because its global jump deduplication is not continuation-sensitive.

## How has it been tested?

- `cargo +nightly fmt --check --all`
- `cargo clippy -p heimdall-vm -p heimdall-disassembler --all-features -- --allow clippy::new_without_default --allow clippy::redundant_field_names --allow clippy::too_many_arguments --allow clippy::format_in_format_args --allow clippy::should_implement_trait`
- `cargo test --workspace --lib --tests`
- Added six unit tests covering PUSH-data decoding, canonical boundaries, direct and unresolved conditional targets, truncated PUSH semantics, and hardfork-inactive opcodes.
