### PR TITLE
fix(ci): lowercase Docker image references

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,11 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      # Docker requires lowercase repository paths, but github.repository keeps
+      # the owner's casing, so lowercase it before it reaches any raw image ref.
+      - name: Prepare image name
+        run: echo "IMAGE=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Prepare platform pair
         run: |
           platform=${{ matrix.platform }}
@@ -46,7 +51,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -67,9 +72,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }}
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -94,6 +99,11 @@ jobs:
       packages: write
 
     steps:
+      # Docker requires lowercase repository paths, but github.repository keeps
+      # the owner's casing, so lowercase it before it reaches any raw image ref.
+      - name: Prepare image name
+        run: echo "IMAGE=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -115,7 +125,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
@@ -127,8 +137,8 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## What changed? Why?

The `Docker` workflow fails on pushes to `main` because `github.repository` is `Jon-Becker/heimdall-rs`, and Docker/OCI require lowercase repository path components.

`docker/metadata-action` normalizes its own `images` input, so the tags it emits were valid, but the raw references assembled from `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}` bypassed that normalization:

- the buildx registry `cache-from` / `cache-to` refs
- the `push-by-digest` output image name
- the `printf` that builds the digest list for `imagetools create`
- the final `imagetools inspect` ref

Each job now derives a lowercased `IMAGE` once, in its first step, via `GITHUB_ENV` (`echo "IMAGE=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_ENV"`), and every raw reference uses `${{ env.IMAGE }}`. A separate variable name is used rather than reassigning `IMAGE_NAME` so there is no dependence on env self-reference or override precedence.

The native arm64 matrix, cargo-chef caching, digest upload/merge flow, tag rules, permissions, and release behavior are unchanged. No changes to the `Dockerfile` or any other workflow.

## Notes to reviewers

- `.github/workflows/docker.yml` — only file changed.
- Workflow-level `IMAGE_NAME: ${{ github.repository }}` is kept as the input to the lowercasing step.
- The new step is the first step of both `build` and `merge`, so `env.IMAGE` is always set before it is read (it is never read in the step that sets it).

## How has it been tested?

The repository has no workflow-lint convention, so validation was local and deterministic:

- Parsed `.github/workflows/docker.yml` with a YAML parser — parses cleanly, both jobs intact.
- Asserted programmatically that every job referencing `env.IMAGE` sets it in its first step, and that no raw `env.IMAGE_NAME`/`github.repository` reference remains in any image or cache ref.
- Simulated the runner's expansion with the real values (`REGISTRY=ghcr.io`, `IMAGE_NAME=Jon-Becker/heimdall-rs`) in bash, yielding `ghcr.io/jon-becker/heimdall-rs`, and asserted it matches the lowercase-only OCI path pattern.

The `Docker` workflow itself only triggers on pushes to `main`/tags and `workflow_dispatch`, so it does not run on this PR; it has not been executed live.
