### PR TITLE
ci(bench): publish the full Criterion HTML report to S3

### DIFF
--- a/.github/BENCH_REPORT_SETUP.md
+++ b/.github/BENCH_REPORT_SETUP.md
@@ -1,0 +1,94 @@
+# Benchmark report hosting
+
+`.github/workflows/bench.yml` uploads the full Criterion HTML report tree
+(`target/criterion/`) to S3 and links it from the benchmark comment on the pull
+request.
+
+The upload is **optional**. When the configuration below is missing, or when the
+pull request comes from a fork, the workflow skips the upload, says so in the
+benchmark comment, and points at the `criterion-report` workflow artifact
+instead. Nothing in this document is provisioned by this repository — the bucket,
+role, and policies have to be created manually.
+
+## Repository variables
+
+All four are [repository *variables*][vars] (Settings → Secrets and variables →
+Actions → Variables), not secrets. No AWS credential is ever stored: the workflow
+authenticates with GitHub OIDC.
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `BENCH_REPORT_S3_BUCKET` | yes | Bucket that receives the report tree. |
+| `BENCH_REPORT_AWS_REGION` | yes | Region the bucket lives in, e.g. `us-east-1`. |
+| `BENCH_REPORT_AWS_ROLE_ARN` | yes | Role assumed via OIDC, e.g. `arn:aws:iam::<account-id>:role/<role-name>`. |
+| `BENCH_REPORT_BASE_URL` | no | Public origin serving the bucket, e.g. a CloudFront distribution. Defaults to `https://<bucket>.s3.<region>.amazonaws.com`. |
+
+Objects are written under a run-scoped prefix so a canceled or superseded run can
+never overwrite a report that is already linked:
+
+```
+<base url>/pull/<pr number>/<run id>-<run attempt>/report/index.html
+```
+
+`.html`, `.svg`, `.css`, and `.js` objects are uploaded with explicit content
+types so the report renders in a browser rather than downloading.
+
+## AWS setup
+
+The bucket needs to be readable by whoever opens the link. Serving it through
+CloudFront with an origin access control (and setting `BENCH_REPORT_BASE_URL` to
+the distribution domain) keeps the bucket itself private; alternatively, allow
+public reads on the `pull/*` prefix. A lifecycle rule expiring `pull/` objects
+after ~30 days keeps the bucket from growing without bound.
+
+Register GitHub as an OIDC provider (`token.actions.githubusercontent.com`,
+audience `sts.amazonaws.com`), then create the role referenced by
+`BENCH_REPORT_AWS_ROLE_ARN` with this trust policy. The `sub` condition limits
+the role to pull requests on this repository — fork pull requests run with a
+read-only token and no `id-token: write` permission, so they cannot reach it.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:Jon-Becker/heimdall-rs:pull_request"
+        }
+      }
+    }
+  ]
+}
+```
+
+The role only ever writes, and only under `pull/`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::<bucket>/pull/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::<bucket>",
+      "Condition": { "StringLike": { "s3:prefix": "pull/*" } }
+    }
+  ]
+}
+```
+
+[vars]: https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,31 +3,200 @@ name: bench
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   runBenchmark:
     name: run benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    env:
+      # Scope the upload to this exact run so a canceled or superseded run can
+      # never overwrite a report that is already linked from the PR.
+      REPORT_PREFIX: pull/${{ github.event.pull_request.number }}/${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: boa-dev/criterion-compare-action@v3
+      - uses: actions/checkout@v4
+      - id: bench
+        uses: boa-dev/criterion-compare-action@v3
         with:
           package: "heimdall-core"
           branchName: ${{ github.base_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Delete old benchmark comments
+
+      # Fork PRs are intentionally denied AWS access, so the artifact is the
+      # fallback that keeps the full report reachable on every run.
+      - name: Upload benchmark report artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-report
+          path: target/criterion
+          if-no-files-found: warn
+
+      - name: Resolve report upload target
+        id: target
+        if: ${{ !cancelled() }}
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          BUCKET: ${{ vars.BENCH_REPORT_S3_BUCKET }}
+          REGION: ${{ vars.BENCH_REPORT_AWS_REGION }}
+          ROLE_ARN: ${{ vars.BENCH_REPORT_AWS_ROLE_ARN }}
+          BASE_URL: ${{ vars.BENCH_REPORT_BASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_FORK" = "true" ]; then
+            reason="this is a fork pull request, which is never given AWS access"
+          elif [ -z "$BUCKET" ] || [ -z "$REGION" ] || [ -z "$ROLE_ARN" ]; then
+            reason="the BENCH_REPORT_* repository variables are not configured"
+          elif [ ! -f target/criterion/report/index.html ]; then
+            reason="the benchmark run produced no Criterion HTML report"
+          fi
+
+          if [ -n "${reason:-}" ]; then
+            echo "Skipping S3 upload: $reason"
+            {
+              echo "enabled=false"
+              echo "skip_reason=$reason"
+              echo "url="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A CloudFront (or equivalent) origin is preferred; fall back to the
+          # bucket's virtual-hosted endpoint when no base URL is configured.
+          base="${BASE_URL:-https://${BUCKET}.s3.${REGION}.amazonaws.com}"
+          {
+            echo "enabled=true"
+            echo "skip_reason="
+            echo "url=${base%/}/${REPORT_PREFIX}/report/index.html"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: ${{ steps.target.outputs.enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.BENCH_REPORT_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.BENCH_REPORT_AWS_REGION }}
+          role-session-name: heimdall-bench-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload Criterion report to S3
+        if: ${{ steps.target.outputs.enabled == 'true' }}
+        env:
+          BUCKET: ${{ vars.BENCH_REPORT_S3_BUCKET }}
+        run: |
+          set -euo pipefail
+          dest="s3://${BUCKET}/${REPORT_PREFIX}"
+
+          # Upload the raw measurement data first, letting the CLI guess its
+          # types, then the browser-facing assets with explicit content types so
+          # the report renders instead of downloading. The two passes cover
+          # disjoint file sets, so neither can shadow the other.
+          aws s3 sync target/criterion "$dest" --only-show-errors \
+            --exclude "*.html" --exclude "*.svg" --exclude "*.css" --exclude "*.js"
+
+          sync_typed() {
+            aws s3 sync target/criterion "$dest" --only-show-errors \
+              --exclude "*" --include "$1" --content-type "$2"
+          }
+          sync_typed "*.html" "text/html; charset=utf-8"
+          sync_typed "*.svg" "image/svg+xml"
+          sync_typed "*.css" "text/css; charset=utf-8"
+          sync_typed "*.js" "text/javascript; charset=utf-8"
+
+      # Forks hold a read-only token and cannot comment at all, so this only runs
+      # for same-repository pull requests.
+      - name: Link the full report from the benchmark comment
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v7
+        env:
+          BENCH_COMMENT_ID: ${{ steps.bench.outputs.comment-id }}
+          REPORT_URL: ${{ steps.target.outputs.url }}
+          SKIP_REASON: ${{ steps.target.outputs.skip_reason }}
         with:
           script: |
+            const marker = '<!-- heimdall-bench-report -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const line = process.env.REPORT_URL
+              ? `:bar_chart: [View the full Criterion report](${process.env.REPORT_URL})`
+              : `:bar_chart: The full Criterion report was not uploaded because ${process.env.SKIP_REASON}. Download the \`criterion-report\` artifact from [the workflow run](${runUrl}) instead.`;
+            const section = `${marker}\n${line}`;
+
+            // Everything from the marker onwards is this step's own output, so
+            // dropping it keeps reruns replacing the link rather than stacking.
+            const withSection = (body) => {
+              const kept = (body || '').split(marker)[0].trimEnd();
+              return kept ? `${kept}\n\n${section}` : section;
+            };
+
+            const commentId = Number(process.env.BENCH_COMMENT_ID);
+            if (commentId) {
+              const { data: comment } = await github.rest.issues.getComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+              });
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body: withSection(comment.body),
+              });
+              return;
+            }
+
+            // The action did not report a comment to amend, so keep the link on a
+            // separate comment that the cleanup step below also prunes.
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const benchmarkComments = comments.filter(
-              c => c.user.login === 'github-actions[bot]' && c.body.includes('Benchmark for')
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes(marker)
             );
-            // Delete all but the most recent benchmark comment
-            for (const comment of benchmarkComments.slice(0, -1)) {
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: withSection(existing.body),
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: section,
+              });
+            }
+
+      - name: Delete old benchmark comments
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- heimdall-bench-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const fromBot = comments.filter(c => c.user.login === 'github-actions[bot]');
+            const benchmarkComments = fromBot.filter(c => c.body.includes('Benchmark for'));
+            // Standalone report links only exist when the action's comment could
+            // not be amended; prune them independently so neither kind stacks up.
+            const reportComments = fromBot.filter(
+              c => c.body.includes(marker) && !c.body.includes('Benchmark for')
+            );
+
+            // Delete all but the most recent comment of each kind
+            for (const comment of [...benchmarkComments.slice(0, -1), ...reportComments.slice(0, -1)]) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,6 @@ tracing-logfmt = "0.3.3"
 rolling-file = "0.2.0"
 paste = "1.0.15"
 once_cell = "1.19"
-criterion = { version = "0.5.1", features = ["async_futures", "async_tokio"] }
+criterion = { version = "0.5.1", features = ["async_futures", "async_tokio", "html_reports"] }
 memory-stats = "1.0.0"
 serde_yaml = "0.9.31"


### PR DESCRIPTION
## What changed? Why?

The benchmark workflow only ever surfaced `critcmp`'s summary table. Criterion's
full HTML report — per-benchmark PDF/iteration plots, regression charts, and the
comparison view — was generated inside `target/criterion/` and thrown away with
the runner.

This publishes that report and links it from the existing benchmark comment.

- **`Cargo.toml`** — Criterion 0.5 does not include `html_reports` in its default
  features, so no HTML report was being written at all. Added the feature to the
  workspace dependency; it is a pure feature flag over dependencies Criterion
  already pulls in, so the lockfile is unchanged.
- **`.github/workflows/bench.yml`** — after `criterion-compare-action` runs, the
  whole `target/criterion/` tree is uploaded to S3 under a **run-scoped prefix**
  (`pull/<pr>/<run id>-<run attempt>/`) so a canceled or superseded run can never
  overwrite a report that is already linked. Auth is GitHub OIDC via
  `aws-actions/configure-aws-credentials@v4` — no AWS secret is stored. The event
  stays `pull_request`, and the upload is gated on the PR not coming from a fork,
  so fork code is never given credentials or OIDC access. Explicit least-privilege
  `permissions` blocks were added (`contents: read` at the workflow level;
  `id-token: write` + `pull-requests: write` on the job).
- **`.github/BENCH_REPORT_SETUP.md`** — documents the four repository variables
  and the IAM trust/permission policies the upload requires.

`.html`, `.svg`, `.css`, and `.js` objects are uploaded with explicit content
types (a second `aws s3 sync` pass over a file set disjoint from the first) so the
report renders in a browser rather than downloading.

The link is appended to the comment `criterion-compare-action` already creates,
addressed by that action's `comment-id` output, behind a stable
`<!-- heimdall-bench-report -->` marker. Reruns strip everything from the marker
onward before re-appending, so the link is replaced rather than stacked and the
benchmark table is preserved. If the action ever stops reporting a comment id, the
link falls back to a separate marked comment, and the cleanup step now prunes both
kinds independently.

Fork PRs and unconfigured repositories are not failures: the full report is
uploaded as a `criterion-report` workflow artifact on **every** run, and when the
S3 path is skipped the comment says why and points at that artifact.

> [!IMPORTANT]
> **No infrastructure was provisioned by this PR.** The bucket, OIDC provider, and
> IAM role described in `.github/BENCH_REPORT_SETUP.md` must be created manually,
> and these repository variables set, before any upload happens:
>
> | Variable | Required | Description |
> | --- | --- | --- |
> | `BENCH_REPORT_S3_BUCKET` | yes | Bucket that receives the report tree. |
> | `BENCH_REPORT_AWS_REGION` | yes | Region the bucket lives in. |
> | `BENCH_REPORT_AWS_ROLE_ARN` | yes | Role assumed via OIDC. |
> | `BENCH_REPORT_BASE_URL` | no | Public origin (e.g. CloudFront). Defaults to `https://<bucket>.s3.<region>.amazonaws.com`. |
>
> Until they exist, this workflow deliberately degrades to the artifact fallback.

## Notes to reviewers

- `.github/workflows/bench.yml` — S3 upload, comment linking, cleanup.
- `.github/BENCH_REPORT_SETUP.md` — new setup documentation.
- `Cargo.toml:176` — `html_reports` feature.

`actions/checkout` in this workflow was bumped `v3` → `v4` to match every other
workflow in the repo and to clear the only `actionlint` finding in this file.

## How has it been tested?

- `actionlint` on `.github/workflows/bench.yml` — clean. (The findings it reports
  in `dependencies.yml`, `heavy-integration.yml`, `release.yml`, and `tests.yml`
  are pre-existing and untouched here.)
- `cargo bench -p heimdall-vm --bench bench_fib` locally — confirms
  `target/criterion/report/index.html` and the per-benchmark SVG/HTML tree are now
  produced, which they were not before the `html_reports` change.
- `cargo +nightly fmt --check --all` — clean.
- The `Resolve report upload target` shell was executed directly against each
  branch. Verified exact URLs and skip reasons:
  - configured, default endpoint → `https://heimdall-bench.s3.us-east-1.amazonaws.com/pull/738/1234-2/report/index.html`
  - configured, `BENCH_REPORT_BASE_URL=https://bench.example.com/` → `https://bench.example.com/pull/738/1234-2/report/index.html` (trailing slash normalized)
  - fork PR / missing variables / missing report → `enabled=false` with the matching reason, and the job continues.
- The comment and cleanup `github-script` bodies were extracted from the workflow
  and run against a stubbed Octokit. Verified: the link is appended to the
  action's comment, a rerun replaces the URL in place (one marker, benchmark table
  intact), the skip path renders the artifact fallback text, the no-`comment-id`
  path creates then updates a single standalone comment, and cleanup keeps only
  the newest comment of each kind while ignoring non-bot comments.

> [!NOTE]
> Live end-to-end validation (a real upload and a browser render) could not be
> performed: `BENCH_REPORT_S3_BUCKET` / `BENCH_REPORT_AWS_REGION` /
> `BENCH_REPORT_AWS_ROLE_ARN` are not configured on this repository and no bucket
> or role exists yet. On this PR the workflow will therefore take the documented
> skip path. Once the variables are set, the next benchmark run performs the first
> real upload.
