### PR TITLE
feat(decompile): retain contextual flow structure

### DIFF
--- a/crates/decompile/src/core/canonical.rs
+++ b/crates/decompile/src/core/canonical.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use hashbrown::HashMap;
 use heimdall_vm::core::{
     context::{analyze_contextual, ContextualCfg, ContextualPoint},
+    control_flow::{analyze_contextual_control_flow, ContextualControlFlow},
     hardfork::HardFork,
     program::{BlockId, Program},
     ssa::{build_contextual_ssa, ContextualSsa},
@@ -31,6 +32,8 @@ pub struct CanonicalAnalysis {
     pub cfg: ContextualCfg,
     /// Contextual stack SSA and effect operands derived from `cfg`.
     pub ssa: ContextualSsa,
+    /// Dominators, post-dominators, SCCs, loops, and structural uncertainty.
+    pub control_flow: ContextualControlFlow,
     /// Legacy-discovered selectors annotated with canonical entry blocks.
     pub function_entries: BTreeMap<String, CanonicalFunctionEntry>,
 }
@@ -51,6 +54,7 @@ pub(crate) fn build_canonical_analysis(
     let program = Program::decode(bytecode, hardfork);
     let cfg = analyze_contextual(&program);
     let ssa = build_contextual_ssa(&cfg);
+    let control_flow = analyze_contextual_control_flow(&cfg);
     let function_entries = selectors
         .iter()
         .map(|(selector, &entry_pc)| {
@@ -61,7 +65,7 @@ pub(crate) fn build_canonical_analysis(
             (selector.clone(), CanonicalFunctionEntry { entry_pc, block })
         })
         .collect();
-    CanonicalAnalysis { program, cfg, ssa, function_entries }
+    CanonicalAnalysis { program, cfg, ssa, control_flow, function_entries }
 }
 
 #[cfg(test)]
@@ -109,5 +113,10 @@ mod tests {
             .flat_map(|block| &block.effects)
             .any(|effect| effect.kind ==
                 heimdall_vm::core::analysis::InstructionEffectKind::StorageWrite));
+        assert_eq!(
+            analysis.control_flow.immediate_dominators.len(),
+            analysis.cfg.entry_states.len()
+        );
+        assert!(analysis.control_flow.is_exact());
     }
 }


### PR DESCRIPTION
## What changed? Why?

Retains canonical contextual control-flow structure in the decompiler sidecar.

`CanonicalAnalysis` now keeps the `ContextualControlFlow` artifact from #753 alongside the canonical program, abstract CFG, versioned expression arenas, contextual SSA, effects, and selector mappings. Upcoming function and region recovery can therefore consume dominators, post-dominators, SCCs, natural loops, irreducibility, and uncertainty without rebuilding or flattening the graph.

Legacy Solidity/Yul and ABI generation remain unchanged.

This PR is stacked on #753.

## Notes to reviewers

- The structural artifact is built directly from the retained `ContextualCfg`, preserving ID consistency with SSA blocks and selector points.
- Consumers must check `control_flow.uncertainty` before treating observed graph structure as complete.
- This is intentionally another sidecar stage; it does not switch production lowering before SESE recovery and typed canonical IR are validated.
- Measured region-analysis overhead is <1ms for USDT and Uniswap V2, 3ms for the Uniswap V3 router, and 96ms for Seaport.

## How has it been tested?

- `cargo test -p heimdall-decompiler --lib` — 75 passed
- `cargo check --workspace --all-targets` — passed
- `cargo +nightly fmt --all -- --check` — passed
- `git diff --check` — passed
- Extended canonical-sidecar coverage to verify structural dominator retention and exactness on a fully resolved test program.
