### PR TITLE
ci: publish evaluation HTML reports

### DIFF
--- a/.github/BENCH_REPORT_SETUP.md
+++ b/.github/BENCH_REPORT_SETUP.md
@@ -2,13 +2,15 @@
 
 `.github/workflows/bench.yml` uploads the full Criterion HTML report tree
 (`target/criterion/`) to S3 and links it from the benchmark comment on the pull
-request.
+request. `.github/workflows/eval.yml` uses the same configuration to upload the
+static `heimdall-eval` report (`heimdall/report.html` plus its `report/` detail
+pages) and links it from the evaluation comment.
 
 The upload is **optional**. When the configuration below is missing, or when the
 pull request comes from a fork, the workflow skips the upload, says so in the
-benchmark comment, and points at the `criterion-report` workflow artifact
-instead. Nothing in this document is provisioned by this repository — the bucket,
-role, and policies have to be created manually.
+relevant pull-request comment, and points at the `criterion-report` or
+`eval-results` workflow artifact instead. Nothing in this document is provisioned
+by this repository — the bucket, role, and policies have to be created manually.
 
 ## Repository variables
 
@@ -24,10 +26,16 @@ authenticates with GitHub OIDC.
 | `BENCH_REPORT_BASE_URL` | no | Public origin serving the bucket, e.g. a CloudFront distribution. Defaults to `https://<bucket>.s3.<region>.amazonaws.com`. |
 
 Objects are written under a run-scoped prefix so a canceled or superseded run can
-never overwrite a report that is already linked:
+never overwrite a report that is already linked. Criterion reports use:
 
 ```
 <base url>/pull/<pr number>/<run id>-<run attempt>/report/index.html
+```
+
+Evaluation reports use:
+
+```
+<base url>/pull/<pr number>/<run id>-<run attempt>/report.html
 ```
 
 `.html`, `.svg`, `.css`, and `.js` objects are uploaded with explicit content
@@ -43,9 +51,12 @@ after ~30 days keeps the bucket from growing without bound.
 
 Register GitHub as an OIDC provider (`token.actions.githubusercontent.com`,
 audience `sts.amazonaws.com`), then create the role referenced by
-`BENCH_REPORT_AWS_ROLE_ARN` with this trust policy. The `sub` condition limits
-the role to pull requests on this repository — fork pull requests run with a
-read-only token and no `id-token: write` permission, so they cannot reach it.
+`BENCH_REPORT_AWS_ROLE_ARN` with this trust policy. The first `sub` value is for
+the pull-request-triggered benchmark workflow. The evaluation workflow is
+triggered by an issue comment and therefore uses the default-branch ref in its
+OIDC subject; replace `main` below if this repository's default branch changes.
+Fork pull requests run with a read-only token and no `id-token: write`
+permission, so they cannot reach it.
 
 ```json
 {
@@ -62,7 +73,10 @@ read-only token and no `id-token: write` permission, so they cannot reach it.
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
         },
         "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:Jon-Becker/heimdall-rs:pull_request"
+          "token.actions.githubusercontent.com:sub": [
+            "repo:Jon-Becker/heimdall-rs:pull_request",
+            "repo:Jon-Becker/heimdall-rs:ref:refs/heads/main"
+          ]
         }
       }
     }

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -314,9 +314,11 @@ jobs:
               '</details>',
               detailsBlock,
               '',
-              '- [x] Run AI Evaluation Suite',
+              '- [ ] Run AI Evaluation Suite',
             ].join('\n');
 
+            // Reset the checkbox after completion so reviewers can request a rerun.
+            // The edited-comment trigger only reacts to unchecked → checked.
             // Replace the request comment so the PR has one live evaluation status.
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
@@ -340,7 +342,7 @@ jobs:
                 '',
                 `The [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval) run failed. See [the workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
                 '',
-                '- [x] Run AI Evaluation Suite',
+                '- [ ] Run AI Evaluation Suite',
               ].join('\n'),
             });
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -85,6 +85,14 @@ jobs:
       needs.resolve-pr.outputs.same_repository == 'true' &&
       needs.resolve-pr.outputs.trusted_requester == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    env:
+      # Scope each report to its exact run so reruns cannot overwrite a report
+      # already linked from the pull request.
+      REPORT_PREFIX: pull/${{ github.event.issue.number }}/${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Show evaluation progress on PR
         uses: actions/github-script@v7
@@ -147,10 +155,74 @@ jobs:
           npm install -g @anthropic-ai/claude-code
           make eval-all
 
+      - name: Generate HTML evaluation report
+        working-directory: heimdall-eval
+        run: make report
+
+      # The benchmark report configuration also hosts evaluation reports. Forks
+      # never receive AWS credentials, even if this workflow is later enabled
+      # for them.
+      - name: Resolve report upload target
+        id: target
+        env:
+          IS_FORK: ${{ needs.resolve-pr.outputs.same_repository != 'true' }}
+          BUCKET: ${{ vars.BENCH_REPORT_S3_BUCKET }}
+          REGION: ${{ vars.BENCH_REPORT_AWS_REGION }}
+          ROLE_ARN: ${{ vars.BENCH_REPORT_AWS_ROLE_ARN }}
+          BASE_URL: ${{ vars.BENCH_REPORT_BASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_FORK" = "true" ]; then
+            reason="this is a fork pull request, which is never given AWS access"
+          elif [ -z "$BUCKET" ] || [ -z "$REGION" ] || [ -z "$ROLE_ARN" ]; then
+            reason="the BENCH_REPORT_* repository variables are not configured"
+          elif [ ! -f heimdall-eval/heimdall/report.html ]; then
+            reason="the evaluation run produced no HTML report"
+          fi
+
+          if [ -n "${reason:-}" ]; then
+            echo "Skipping S3 upload: $reason"
+            {
+              echo "enabled=false"
+              echo "skip_reason=$reason"
+              echo "url="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="${BASE_URL:-https://${BUCKET}.s3.${REGION}.amazonaws.com}"
+          {
+            echo "enabled=true"
+            echo "skip_reason="
+            echo "url=${base%/}/${REPORT_PREFIX}/report.html"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: ${{ steps.target.outputs.enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.BENCH_REPORT_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.BENCH_REPORT_AWS_REGION }}
+          role-session-name: heimdall-eval-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload evaluation report to S3
+        if: ${{ steps.target.outputs.enabled == 'true' }}
+        env:
+          BUCKET: ${{ vars.BENCH_REPORT_S3_BUCKET }}
+        run: |
+          set -euo pipefail
+          dest="s3://${BUCKET}/${REPORT_PREFIX}"
+          aws s3 cp heimdall-eval/heimdall/report.html "$dest/report.html" \
+            --content-type "text/html; charset=utf-8" --only-show-errors
+          aws s3 sync heimdall-eval/heimdall/report "$dest/report" \
+            --content-type "text/html; charset=utf-8" --only-show-errors
+
       - name: Comment on PR
         uses: actions/github-script@v7
         env:
           EVAL_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+          REPORT_URL: ${{ steps.target.outputs.url }}
+          REPORT_SKIP_REASON: ${{ steps.target.outputs.skip_reason }}
         with:
           script: |
             const fs = require('fs');
@@ -228,11 +300,19 @@ jobs:
               `## ${icon} AI Evaluation Suite for ${process.env.EVAL_SHA}`,
               '',
               `Completed [heimdall-eval](https://github.com/Jon-Becker/heimdall-eval). [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+              process.env.REPORT_URL
+                ? `:bar_chart: [View the full HTML evaluation report](${process.env.REPORT_URL}).`
+                : `:bar_chart: The full HTML evaluation report was not uploaded because ${process.env.REPORT_SKIP_REASON}. Download the \`eval-results\` artifact from the workflow run instead.`,
+              '',
+              '<details>',
+              '<summary>:bar_chart: View evaluation scores</summary>',
               '',
               '| Test Case | CFG | Decompilation |',
               '|-----------|-----|---------------|',
               tableRows,
-              `| **Average** | **${avgCfg}** | **${avgDecomp}** |${detailsBlock}`,
+              `| **Average** | **${avgCfg}** | **${avgDecomp}** |`,
+              '</details>',
+              detailsBlock,
               '',
               '- [x] Run AI Evaluation Suite',
             ].join('\n');
@@ -265,6 +345,7 @@ jobs:
             });
 
       - name: Upload eval artifacts
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: eval-results
@@ -272,3 +353,6 @@ jobs:
             heimdall-eval/heimdall/*/eval.json
             heimdall-eval/heimdall/*/cfg_eval.json
             heimdall-eval/heimdall/evals.json
+            heimdall-eval/heimdall/report.html
+            heimdall-eval/heimdall/report/
+          if-no-files-found: warn


### PR DESCRIPTION
## What changed? Why?

- Generate the static `heimdall-eval` HTML report after an evaluation run, publish it to the existing configured S3 report bucket, and link it from the PR comment.
- Preserve the workflow-artifact fallback when S3 is unavailable and collapse evaluation scores in the PR comment.
- Reset the evaluation checkbox after both successful and failed runs so a reviewer can request another run.

## Notes to reviewers

- `.github/workflows/eval.yml` adds report generation, OIDC-based S3 upload, comment linking, and rerun-checkbox reset behavior.
- `.github/BENCH_REPORT_SETUP.md` documents the shared report-hosting configuration and required OIDC subject for the issue-comment workflow.

## How has it been tested?

- Parsed `.github/workflows/eval.yml` as YAML.
- Ran `git diff --check`.
- Ran `python3 -m unittest discover -s scripts -p test_*.py` in `heimdall-eval` (9 tests passed).
- Parsed both JSON IAM policy examples in the setup documentation.