### PR TITLE
feat(decompile): sort decompiled functions alphabetically

### DIFF
--- a/crates/core/tests/test_decompile.rs
+++ b/crates/core/tests/test_decompile.rs
@@ -583,4 +583,61 @@ mod integration_tests {
             assert!(error_obj.contains_key("signature"), "Error should have a signature field");
         }
     }
+
+    /// A minimal local dispatcher which routes three selectors, in an order which does not match
+    /// their alphabetical order. Used to assert deterministic output without any RPC dependency.
+    const MULTI_SELECTOR_BYTECODE: &str = "0x60003560e01c8063ffffff011461002c578063111111011461003857806388888801146100405760006000fd5b60005460005260206000f35b600435600155005b60043560020260005260206000f3";
+
+    async fn decompile_local(include_solidity: bool) -> String {
+        let args = DecompilerArgsBuilder::new()
+            .target(MULTI_SELECTOR_BYTECODE.to_string())
+            .skip_resolving(true)
+            .include_solidity(include_solidity)
+            .include_yul(!include_solidity)
+            .build()
+            .expect("failed to build args");
+
+        decompile(args)
+            .await
+            .expect("failed to decompile")
+            .source
+            .expect("decompile source is empty")
+    }
+
+    #[tokio::test]
+    async fn test_decompile_output_is_deterministic_solidity() {
+        let first = decompile_local(true).await;
+        let second = decompile_local(true).await;
+
+        // repeated decompilation of the same bytecode is byte-identical
+        assert_eq!(first, second);
+
+        // functions are emitted in alphabetical order
+        let names = first
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("function "))
+            .map(|signature| signature.split('(').next().expect("empty signature").to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec!["Unresolved_11111101", "Unresolved_88888801", "Unresolved_ffffff01"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decompile_output_is_deterministic_yul() {
+        let first = decompile_local(false).await;
+        let second = decompile_local(false).await;
+
+        // repeated decompilation of the same bytecode is byte-identical
+        assert_eq!(first, second);
+
+        // cases are emitted in alphabetical order of their emitted function names
+        let cases = first
+            .lines()
+            .map(|line| line.trim())
+            .filter(|line| line.starts_with("case 0x"))
+            .collect::<Vec<_>>();
+        assert_eq!(cases, vec!["case 0x11111101 {", "case 0x88888801 {", "case 0xffffff01 {"]);
+    }
 }

--- a/crates/core/tests/test_decompile.rs
+++ b/crates/core/tests/test_decompile.rs
@@ -162,7 +162,7 @@ mod integration_tests {
             "function Unresolved_2e1a7d4d(uint256 arg0) public {",
             "string public unresolved_06fdde03; // storage slot: 0x00",
             "string public unresolved_95d89b41; // storage slot: 0x01",
-            "uint8 store_e; // storage slot: 0x02",
+            "uint8 store_d; // storage slot: 0x02",
             "mapping(address => uint256) public unresolved_70a08231; // storage slot: 0x03",
             "mapping(address => mapping(address => uint256)) public unresolved_dd62ed3e; // storage slot: 0x04",
             "function Unresolved_a9059cbb(address arg0, uint256 arg1) public returns (bool) {",

--- a/crates/decompile/src/core/mod.rs
+++ b/crates/decompile/src/core/mod.rs
@@ -40,7 +40,7 @@ use crate::{
         resolve::match_parameters,
     },
     error::Error,
-    interfaces::{AnalyzedFunction, DecompilerArgs},
+    interfaces::{sort_analyzed_functions, AnalyzedFunction, DecompilerArgs},
 };
 use tracing::{debug, info, warn};
 
@@ -339,6 +339,10 @@ pub async fn decompile(args: DecompilerArgs) -> Result<DecompileResult, Error> {
             f.selector
         );
     });
+
+    // sort the analyzed functions into a deterministic order, so that repeated decompilation of
+    // the same bytecode always produces identical output
+    sort_analyzed_functions(&mut analyzed_functions);
 
     // get a new PostprocessorOrchestrator
     // note: this will do nothing if the include_solidity and include_yul flags are false

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -42,10 +42,7 @@ pub(crate) fn build_abi(
         };
 
         // determine the name of the function
-        let name = match f.resolved_function {
-            Some(ref sig) => sig.name.clone(),
-            None => format!("Unresolved_{}", f.selector),
-        };
+        let name = f.emitted_name();
 
         let function = Function {
             name: name.clone(),
@@ -91,7 +88,7 @@ pub(crate) fn build_abi(
         };
 
         // add functions errors
-        f.errors.iter().for_each(|error_selector| {
+        f.sorted_errors().iter().for_each(|error_selector| {
             // determine the name of the error
             let (name, inputs) = match all_resolved_errors
                 .get(&encode_hex_reduced(*error_selector).replacen("0x", "", 1))
@@ -119,7 +116,7 @@ pub(crate) fn build_abi(
         });
 
         // add functions events
-        f.events.iter().for_each(|event_selector| {
+        f.sorted_events().iter().for_each(|event_selector| {
             // determine the name of the event
             let (name, inputs) = match all_resolved_logs
                 .get(&encode_hex_reduced(*event_selector).replacen("0x", "", 1))
@@ -166,17 +163,8 @@ pub(crate) fn build_abi_with_details(
     let mut abi_array = serde_json::to_value(abi)?;
 
     // Create a map of function selectors for quick lookup
-    let function_map: HashMap<String, &AnalyzedFunction> = functions
-        .iter()
-        .filter(|f| !f.fallback)
-        .map(|f| {
-            let name = match f.resolved_function {
-                Some(ref sig) => sig.name.clone(),
-                None => format!("Unresolved_{}", f.selector),
-            };
-            (name, f)
-        })
-        .collect();
+    let function_map: HashMap<String, &AnalyzedFunction> =
+        functions.iter().filter(|f| !f.fallback).map(|f| (f.emitted_name(), f)).collect();
 
     // Add selector and signature to each function in the ABI
     if let Some(items) = abi_array.as_array_mut() {

--- a/crates/decompile/src/core/out/abi.rs
+++ b/crates/decompile/src/core/out/abi.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_abi(
         };
 
         // add functions errors
-        f.sorted_errors().iter().for_each(|error_selector| {
+        f.errors.iter().for_each(|error_selector| {
             // determine the name of the error
             let (name, inputs) = match all_resolved_errors
                 .get(&encode_hex_reduced(*error_selector).replacen("0x", "", 1))
@@ -116,7 +116,7 @@ pub(crate) fn build_abi(
         });
 
         // add functions events
-        f.sorted_events().iter().for_each(|event_selector| {
+        f.events.iter().for_each(|event_selector| {
             // determine the name of the event
             let (name, inputs) = match all_resolved_logs
                 .get(&encode_hex_reduced(*event_selector).replacen("0x", "", 1))

--- a/crates/decompile/src/core/out/source.rs
+++ b/crates/decompile/src/core/out/source.rs
@@ -1,4 +1,4 @@
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use std::{str::FromStr, time::Instant};
 
 use alloy::primitives::U256;
@@ -213,10 +213,7 @@ fn get_function_header(f: &AnalyzedFunction) -> Vec<String> {
     }
 
     // determine the name of the function
-    let function_name = match f.resolved_function {
-        Some(ref sig) => sig.name.clone(),
-        None => format!("Unresolved_{}", f.selector),
-    };
+    let function_name = f.emitted_name();
 
     let function_signature = match f.resolved_function {
         Some(ref sig) => format!(
@@ -402,12 +399,18 @@ fn get_event_and_error_declarations(
     functions: &[AnalyzedFunction],
     all_resolved_errors: &HashMap<String, ResolvedError>,
     all_resolved_logs: &HashMap<String, ResolvedLog>,
-) -> HashMap<String, (String, String)> {
+) -> Vec<(String, (String, String))> {
     let mut output = HashMap::new();
 
-    // get all events and errors
-    let all_events = functions.iter().flat_map(|f| f.events.clone()).collect::<HashSet<_>>();
-    let all_errors = functions.iter().flat_map(|f| f.errors.clone()).collect::<HashSet<_>>();
+    // get all events and errors, sorted by selector for deterministic output
+    let mut all_events =
+        functions.iter().flat_map(|f| f.events.iter().copied()).collect::<Vec<_>>();
+    all_events.sort_unstable();
+    all_events.dedup();
+    let mut all_errors =
+        functions.iter().flat_map(|f| f.errors.iter().copied()).collect::<Vec<_>>();
+    all_errors.sort_unstable();
+    all_errors.dedup();
 
     // add event declarations
     all_events.iter().for_each(|event_selector| {
@@ -473,7 +476,17 @@ fn get_event_and_error_declarations(
         );
     });
 
-    output
+    // sort the declarations, so that the generated output is deterministic
+    let mut declarations = output.into_iter().collect::<Vec<_>>();
+    declarations.sort_by(
+        |(a_unresolved, (a_declaration, a_typ)), (b_unresolved, (b_declaration, b_typ))| {
+            a_typ
+                .cmp(b_typ)
+                .then_with(|| a_declaration.cmp(b_declaration))
+                .then_with(|| a_unresolved.cmp(b_unresolved))
+        },
+    );
+    declarations
 }
 
 /// Helper function which will indent the source code.
@@ -516,6 +529,223 @@ fn get_indentation_imbalance(source: &[String]) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interfaces::sort_analyzed_functions;
+    use hashbrown::HashSet;
+    use heimdall_common::ether::signatures::ResolvedFunction;
+
+    /// Builds a function with a distinguishable body, so we can assert that bodies stay attached
+    /// to their headers when functions are reordered.
+    fn analyzed_function(
+        selector: &str,
+        resolved: Option<(&str, &str)>,
+        analyzer_type: AnalyzerType,
+    ) -> AnalyzedFunction {
+        let mut function = AnalyzedFunction::new(selector, false);
+        function.analyzer_type = analyzer_type;
+        function.logic = vec![format!("return {selector};")];
+        function.pure = false;
+        function.view = false;
+        function.payable = false;
+        function.resolved_function = resolved.map(|(name, signature)| ResolvedFunction {
+            name: name.to_string(),
+            signature: signature.to_string(),
+            inputs: vec![],
+            decoded_inputs: None,
+        });
+        function
+    }
+
+    fn fixture(analyzer_type: AnalyzerType) -> Vec<AnalyzedFunction> {
+        let mut transfer = analyzed_function(
+            "a9059cbb",
+            Some(("transfer", "transfer(address,uint256)")),
+            analyzer_type,
+        );
+        transfer.events = HashSet::from([U256::from(1), U256::from(2)]);
+        let mut approve = analyzed_function(
+            "095ea7b3",
+            Some(("approve", "approve(address,uint256)")),
+            analyzer_type,
+        );
+        approve.errors = HashSet::from([U256::from(3), U256::from(4)]);
+        let mut fallback = analyzed_function("00000000", None, analyzer_type);
+        fallback.fallback = true;
+
+        vec![
+            transfer,
+            approve,
+            analyzed_function("18160ddd", Some(("totalSupply", "totalSupply()")), analyzer_type),
+            analyzed_function("deadbeef", None, analyzer_type),
+            analyzed_function("00c0ffee", None, analyzer_type),
+            fallback,
+        ]
+    }
+
+    fn permutations(functions: &[AnalyzedFunction]) -> Vec<Vec<AnalyzedFunction>> {
+        let reversed = functions.iter().rev().cloned().collect::<Vec<_>>();
+        let mut rotated = functions.to_vec();
+        rotated.rotate_left(3);
+        vec![functions.to_vec(), reversed, rotated]
+    }
+
+    async fn build(functions: &[AnalyzedFunction]) -> String {
+        build_source(
+            functions,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+            String::new(),
+            String::new(),
+        )
+        .await
+        .expect("failed to build source")
+        .expect("source is empty")
+    }
+
+    /// Returns the emitted function names, in the order they appear in the source.
+    fn emitted_names(source: &str) -> Vec<String> {
+        source
+            .lines()
+            .filter_map(|line| {
+                line.trim()
+                    .strip_prefix("function ")
+                    .or_else(|| line.trim().strip_prefix("* @custom:signature    "))
+            })
+            .map(|signature| {
+                signature.split('(').next().expect("signature is empty").trim().to_string()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn solidity_functions_are_sorted_alphabetically() {
+        let mut sources = Vec::new();
+        for mut functions in permutations(&fixture(AnalyzerType::Solidity)) {
+            sort_analyzed_functions(&mut functions);
+            sources.push(build(&functions).await);
+        }
+
+        // repeated generation from any insertion order is byte-identical
+        assert!(sources.windows(2).all(|window| window[0] == window[1]));
+
+        let source = &sources[0];
+        let names = emitted_names(source);
+        assert_eq!(
+            names,
+            vec![
+                "approve",
+                "totalSupply",
+                "transfer",
+                "Unresolved_00c0ffee",
+                "Unresolved_deadbeef",
+            ]
+        );
+
+        // function bodies remain attached to their headers
+        let lines = source.lines().map(|line| line.trim()).collect::<Vec<_>>();
+        for (name, selector) in [
+            ("approve", "095ea7b3"),
+            ("totalSupply", "18160ddd"),
+            ("transfer", "a9059cbb"),
+            ("Unresolved_00c0ffee", "00c0ffee"),
+            ("Unresolved_deadbeef", "deadbeef"),
+        ] {
+            let header = lines
+                .iter()
+                .position(|line| line.starts_with(&format!("function {name}(")))
+                .unwrap_or_else(|| panic!("missing function {name}"));
+            assert_eq!(lines[header + 1], format!("return {selector};"));
+        }
+
+        // the fallback function is still emitted as a fallback
+        let fallback = lines
+            .iter()
+            .position(|line| *line == "fallback() external payable {")
+            .expect("missing fallback");
+        assert_eq!(lines[fallback + 1], "return 00000000;");
+    }
+
+    #[tokio::test]
+    async fn yul_cases_are_sorted_alphabetically() {
+        let mut sources = Vec::new();
+        for mut functions in permutations(&fixture(AnalyzerType::Yul)) {
+            sort_analyzed_functions(&mut functions);
+            sources.push(build(&functions).await);
+        }
+
+        assert!(sources.windows(2).all(|window| window[0] == window[1]));
+
+        // the yul header declares helper functions of its own, so only the trailing signatures
+        // belong to the decompiled contract
+        let source = &sources[0];
+        let names = emitted_names(source);
+        assert_eq!(
+            names[names.len() - 5..],
+            ["approve", "totalSupply", "transfer", "Unresolved_00c0ffee", "Unresolved_deadbeef"]
+        );
+
+        let lines = source.lines().map(|line| line.trim()).collect::<Vec<_>>();
+        let cases =
+            lines.iter().filter(|line| line.starts_with("case 0x")).copied().collect::<Vec<_>>();
+        assert_eq!(
+            cases,
+            vec![
+                "case 0x095ea7b3 {",
+                "case 0x18160ddd {",
+                "case 0xa9059cbb {",
+                "case 0x00c0ffee {",
+                "case 0xdeadbeef {",
+            ]
+        );
+
+        // the fallback function is still emitted as the default case
+        let fallback = lines.iter().position(|line| *line == "default {").expect("missing default");
+        assert_eq!(lines[fallback + 1], "return 00000000;");
+    }
+
+    #[tokio::test]
+    async fn overloads_are_sorted_by_signature() {
+        let mut functions = vec![
+            analyzed_function(
+                "a9059cbb",
+                Some(("transfer", "transfer(address,uint256)")),
+                AnalyzerType::Solidity,
+            ),
+            analyzed_function(
+                "1a695230",
+                Some(("transfer", "transfer(address)")),
+                AnalyzerType::Solidity,
+            ),
+        ];
+        sort_analyzed_functions(&mut functions);
+        assert_eq!(
+            functions.iter().map(|f| f.selector.clone()).collect::<Vec<_>>(),
+            vec!["1a695230", "a9059cbb"]
+        );
+    }
+
+    #[test]
+    fn event_and_error_declarations_are_sorted() {
+        let mut function = AnalyzedFunction::new("a9059cbb", false);
+        function.events = HashSet::from([U256::from(0xbb) << 248, U256::from(0xaa) << 248]);
+        function.errors = HashSet::from([U256::from(0xdd) << 248, U256::from(0xcc) << 248]);
+
+        let declarations =
+            get_event_and_error_declarations(&[function], &HashMap::new(), &HashMap::new());
+        assert_eq!(
+            declarations
+                .iter()
+                .map(|(_, (declaration, typ))| format!("{typ} {declaration}"))
+                .collect::<Vec<_>>(),
+            vec![
+                "error CustomError_cc000000();",
+                "error CustomError_dd000000();",
+                "event Event_aa000000();",
+                "event Event_bb000000();",
+            ]
+        );
+    }
 
     #[test]
     fn duplicate_getters_are_not_collapsed() {

--- a/crates/decompile/src/core/out/source.rs
+++ b/crates/decompile/src/core/out/source.rs
@@ -1,5 +1,5 @@
 use hashbrown::HashMap;
-use std::{str::FromStr, time::Instant};
+use std::{collections::BTreeSet, str::FromStr, time::Instant};
 
 use alloy::primitives::U256;
 use alloy_json_abi::StateMutability;
@@ -75,12 +75,10 @@ pub(crate) async fn build_source(
     }
 
     // add event and error declarations
-    let resolved_event_error_map =
+    let declarations =
         get_event_and_error_declarations(functions, all_resolved_errors, all_resolved_logs);
     if analyzer_type == AnalyzerType::Solidity {
-        resolved_event_error_map.iter().for_each(|(_, (resolved_name, typ))| {
-            source.push(format!("{typ} {resolved_name}"));
-        });
+        source.extend(declarations.iter().map(|declaration| declaration.line.clone()));
 
         // add the fallback function, if it exists
         if let Some(fallback) = functions.iter().find(|f| f.fallback) {
@@ -130,11 +128,8 @@ pub(crate) async fn build_source(
     let mut source = source.join("\n");
 
     // replace all custom event and error declarations with their resolved names
-    resolved_event_error_map.iter().for_each(|(unresolved_name, (resolved_name, _))| {
-        // get only the name of both (remove `(..)`)
-        let unresolved_name = unresolved_name.split('(').next().expect("unresolved name is empty");
-        let resolved_name = resolved_name.split('(').next().expect("resolved name is empty");
-        source = source.replace(unresolved_name, resolved_name);
+    declarations.iter().for_each(|declaration| {
+        source = source.replace(&declaration.unresolved_name, &declaration.name);
     });
 
     // replace all storage variables w/ getters w/ their resolved names
@@ -394,26 +389,34 @@ fn get_storage_variables(
     output
 }
 
-/// Helper function which will get the event and error declarations for the decompiled source code.
+/// A single event or custom error declaration emitted in the decompiled source code.
+struct Declaration {
+    /// the name the declaration is emitted with before resolution, i.e. `Event_ddf252ad`
+    unresolved_name: String,
+    /// the name the declaration is emitted with, i.e. `Transfer`
+    name: String,
+    /// the full declaration line, i.e. `event Transfer(address, address);`
+    line: String,
+}
+
+/// Helper function which will get the event and error declarations for the decompiled source code,
+/// deduplicated by their unresolved name and sorted for deterministic output.
 fn get_event_and_error_declarations(
     functions: &[AnalyzedFunction],
     all_resolved_errors: &HashMap<String, ResolvedError>,
     all_resolved_logs: &HashMap<String, ResolvedLog>,
-) -> Vec<(String, (String, String))> {
-    let mut output = HashMap::new();
-
-    // get all events and errors, sorted by selector for deterministic output
-    let mut all_events =
-        functions.iter().flat_map(|f| f.events.iter().copied()).collect::<Vec<_>>();
-    all_events.sort_unstable();
-    all_events.dedup();
-    let mut all_errors =
-        functions.iter().flat_map(|f| f.errors.iter().copied()).collect::<Vec<_>>();
-    all_errors.sort_unstable();
-    all_errors.dedup();
+) -> Vec<Declaration> {
+    let mut declarations = HashMap::new();
 
     // add event declarations
+    let all_events =
+        functions.iter().flat_map(|f| f.events.iter().copied()).collect::<BTreeSet<_>>();
     all_events.iter().for_each(|event_selector| {
+        let unresolved_name = format!(
+            "Event_{}",
+            event_selector.to_lower_hex().replacen("0x", "", 1).get(0..8).unwrap_or("00000000")
+        );
+
         // determine the name of the event
         let (name, inputs) = match all_resolved_logs
             .get(&encode_hex_reduced(*event_selector).replacen("0x", "", 1))
@@ -421,31 +424,28 @@ fn get_event_and_error_declarations(
             Some(event) => {
                 (event.name.clone(), event.inputs().iter().map(|i| i.to_string()).collect())
             }
-            None => (
-                format!(
-                    "Event_{}",
-                    event_selector
-                        .to_lower_hex()
-                        .replacen("0x", "", 1)
-                        .get(0..8)
-                        .unwrap_or("00000000")
-                ),
-                vec![],
-            ),
+            None => (unresolved_name.clone(), vec![]),
         };
 
-        let unresolved_name = format!(
-            "Event_{}",
-            event_selector.to_lower_hex().replacen("0x", "", 1).get(0..8).unwrap_or("00000000")
-        );
-        output.insert(
-            unresolved_name,
-            (format!("{name}({});", inputs.join(", ")), "event".to_string()),
+        declarations.insert(
+            unresolved_name.clone(),
+            Declaration {
+                unresolved_name,
+                line: format!("event {name}({});", inputs.join(", ")),
+                name,
+            },
         );
     });
 
     // add error declarations
+    let all_errors =
+        functions.iter().flat_map(|f| f.errors.iter().copied()).collect::<BTreeSet<_>>();
     all_errors.iter().for_each(|error_selector| {
+        let unresolved_name = format!(
+            "CustomError_{}",
+            error_selector.to_lower_hex().replacen("0x", "", 1).get(0..8).unwrap_or("00000000")
+        );
+
         // determine the name of the error
         let (name, inputs) = match all_resolved_errors
             .get(&encode_hex_reduced(*error_selector).replacen("0x", "", 1))
@@ -453,39 +453,22 @@ fn get_event_and_error_declarations(
             Some(error) => {
                 (error.name.clone(), error.inputs().iter().map(|i| i.to_string()).collect())
             }
-            None => (
-                format!(
-                    "CustomError_{}",
-                    error_selector
-                        .to_lower_hex()
-                        .replacen("0x", "", 1)
-                        .get(0..8)
-                        .unwrap_or("00000000")
-                ),
-                vec![],
-            ),
+            None => (unresolved_name.clone(), vec![]),
         };
 
-        let unresolved_name = format!(
-            "CustomError_{}",
-            error_selector.to_lower_hex().replacen("0x", "", 1).get(0..8).unwrap_or("00000000")
-        );
-        output.insert(
-            unresolved_name,
-            (format!("{name}({});", inputs.join(", ")), "error".to_string()),
+        declarations.insert(
+            unresolved_name.clone(),
+            Declaration {
+                unresolved_name,
+                line: format!("error {name}({});", inputs.join(", ")),
+                name,
+            },
         );
     });
 
     // sort the declarations, so that the generated output is deterministic
-    let mut declarations = output.into_iter().collect::<Vec<_>>();
-    declarations.sort_by(
-        |(a_unresolved, (a_declaration, a_typ)), (b_unresolved, (b_declaration, b_typ))| {
-            a_typ
-                .cmp(b_typ)
-                .then_with(|| a_declaration.cmp(b_declaration))
-                .then_with(|| a_unresolved.cmp(b_unresolved))
-        },
-    );
+    let mut declarations = declarations.into_values().collect::<Vec<_>>();
+    declarations.sort_unstable_by(|a, b| a.line.cmp(&b.line));
     declarations
 }
 
@@ -530,7 +513,6 @@ fn get_indentation_imbalance(source: &[String]) -> i32 {
 mod tests {
     use super::*;
     use crate::interfaces::sort_analyzed_functions;
-    use hashbrown::HashSet;
     use heimdall_common::ether::signatures::ResolvedFunction;
 
     /// Builds a function with a distinguishable body, so we can assert that bodies stay attached
@@ -561,13 +543,13 @@ mod tests {
             Some(("transfer", "transfer(address,uint256)")),
             analyzer_type,
         );
-        transfer.events = HashSet::from([U256::from(1), U256::from(2)]);
+        transfer.events = BTreeSet::from([U256::from(1), U256::from(2)]);
         let mut approve = analyzed_function(
             "095ea7b3",
             Some(("approve", "approve(address,uint256)")),
             analyzer_type,
         );
-        approve.errors = HashSet::from([U256::from(3), U256::from(4)]);
+        approve.errors = BTreeSet::from([U256::from(3), U256::from(4)]);
         let mut fallback = analyzed_function("00000000", None, analyzer_type);
         fallback.fallback = true;
 
@@ -726,24 +708,61 @@ mod tests {
     }
 
     #[test]
+    fn names_are_sorted_case_insensitively() {
+        let mut functions = vec![
+            analyzed_function("00000001", Some(("Beta", "Beta()")), AnalyzerType::Solidity),
+            analyzed_function("00000002", Some(("alpha", "alpha()")), AnalyzerType::Solidity),
+            analyzed_function(
+                "00000003",
+                Some(("Transfer", "Transfer(address)")),
+                AnalyzerType::Solidity,
+            ),
+            analyzed_function(
+                "00000004",
+                Some(("transfer", "transfer(address,uint256)")),
+                AnalyzerType::Solidity,
+            ),
+        ];
+        sort_analyzed_functions(&mut functions);
+
+        // names which only differ in case are tie-broken by their resolved signature
+        assert_eq!(
+            functions.iter().map(|f| f.emitted_name()).collect::<Vec<_>>(),
+            vec!["alpha", "Beta", "Transfer", "transfer"]
+        );
+    }
+
+    #[test]
     fn event_and_error_declarations_are_sorted() {
         let mut function = AnalyzedFunction::new("a9059cbb", false);
-        function.events = HashSet::from([U256::from(0xbb) << 248, U256::from(0xaa) << 248]);
-        function.errors = HashSet::from([U256::from(0xdd) << 248, U256::from(0xcc) << 248]);
+        function.events = BTreeSet::from([U256::from(0xbb) << 248, U256::from(0xaa) << 248]);
+        function.errors = BTreeSet::from([U256::from(0xdd) << 248, U256::from(0xcc) << 248]);
 
         let declarations =
             get_event_and_error_declarations(&[function], &HashMap::new(), &HashMap::new());
         assert_eq!(
-            declarations
-                .iter()
-                .map(|(_, (declaration, typ))| format!("{typ} {declaration}"))
-                .collect::<Vec<_>>(),
+            declarations.iter().map(|d| d.line.clone()).collect::<Vec<_>>(),
             vec![
                 "error CustomError_cc000000();",
                 "error CustomError_dd000000();",
                 "event Event_aa000000();",
                 "event Event_bb000000();",
             ]
+        );
+    }
+
+    #[test]
+    fn declarations_are_deduplicated_by_unresolved_name() {
+        // error selectors are stored as 4 byte values, so every unresolved error shares the
+        // `CustomError_00000000` name and only the last one is declared
+        let mut function = AnalyzedFunction::new("a9059cbb", false);
+        function.errors = BTreeSet::from([U256::from(0x11), U256::from(0x22)]);
+
+        let declarations =
+            get_event_and_error_declarations(&[function], &HashMap::new(), &HashMap::new());
+        assert_eq!(
+            declarations.iter().map(|d| d.line.clone()).collect::<Vec<_>>(),
+            vec!["error CustomError_00000000();"]
         );
     }
 

--- a/crates/decompile/src/core/postprocess.rs
+++ b/crates/decompile/src/core/postprocess.rs
@@ -421,8 +421,13 @@ impl PostprocessOrchestrator {
 
         // if this is a getter, replace function.maybe_getter_for with the actual getter
         if let Some(getter_for) = self.state.maybe_getter_for.as_ref() {
-            if let Some((name, _)) =
-                self.state.storage_root_slots.iter().find(|(_, slot)| *slot == getter_for)
+            // the smallest matching name is used, since map iteration order is not stable
+            if let Some((name, _)) = self
+                .state
+                .storage_root_slots
+                .iter()
+                .filter(|(_, slot)| *slot == getter_for)
+                .min_by_key(|(name, _)| *name)
             {
                 function.maybe_getter_for = Some(name.clone());
             }

--- a/crates/decompile/src/interfaces/function.rs
+++ b/crates/decompile/src/interfaces/function.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use hashbrown::{HashMap, HashSet};
 
 use alloy::primitives::U256;
@@ -36,10 +38,10 @@ pub(crate) struct AnalyzedFunction {
     pub logic: Vec<String>,
 
     /// holds all found event selectors found
-    pub events: HashSet<U256>,
+    pub events: BTreeSet<U256>,
 
     /// holds all found custom error selectors found
-    pub errors: HashSet<U256>,
+    pub errors: BTreeSet<U256>,
 
     /// stores the matched resolved function for this Functon
     pub resolved_function: Option<ResolvedFunction>,
@@ -102,8 +104,8 @@ impl AnalyzedFunction {
             returns: None,
             statements: Vec::new(),
             logic: Vec::new(),
-            events: HashSet::new(),
-            errors: HashSet::new(),
+            events: BTreeSet::new(),
+            errors: BTreeSet::new(),
             resolved_function: None,
             notices: Vec::new(),
             pure: true,
@@ -170,20 +172,6 @@ impl AnalyzedFunction {
         arguments
     }
 
-    /// Get the event selectors in a sorted vec
-    pub(crate) fn sorted_events(&self) -> Vec<U256> {
-        let mut events: Vec<_> = self.events.iter().copied().collect();
-        events.sort_unstable();
-        events
-    }
-
-    /// Get the custom error selectors in a sorted vec
-    pub(crate) fn sorted_errors(&self) -> Vec<U256> {
-        let mut errors: Vec<_> = self.errors.iter().copied().collect();
-        errors.sort_unstable();
-        errors
-    }
-
     /// The name this function is emitted with in the generated output
     pub(crate) fn emitted_name(&self) -> String {
         match self.resolved_function {
@@ -195,11 +183,9 @@ impl AnalyzedFunction {
     /// The key used to order functions in the generated output. Functions are ordered
     /// alphabetically by their emitted name, using the resolved signature (for overloads) and
     /// the selector (for unresolved names) as tie-breakers.
-    fn output_order_key(&self) -> (String, String, String, String) {
-        let name = self.emitted_name();
+    fn output_order_key(&self) -> (String, String, String) {
         (
-            name.to_lowercase(),
-            name,
+            self.emitted_name().to_lowercase(),
             self.resolved_function.as_ref().map(|sig| sig.signature.clone()).unwrap_or_default(),
             self.selector.clone(),
         )

--- a/crates/decompile/src/interfaces/function.rs
+++ b/crates/decompile/src/interfaces/function.rs
@@ -169,4 +169,45 @@ impl AnalyzedFunction {
         arguments.sort_by(|x, y| x.0.cmp(&y.0));
         arguments
     }
+
+    /// Get the event selectors in a sorted vec
+    pub(crate) fn sorted_events(&self) -> Vec<U256> {
+        let mut events: Vec<_> = self.events.iter().copied().collect();
+        events.sort_unstable();
+        events
+    }
+
+    /// Get the custom error selectors in a sorted vec
+    pub(crate) fn sorted_errors(&self) -> Vec<U256> {
+        let mut errors: Vec<_> = self.errors.iter().copied().collect();
+        errors.sort_unstable();
+        errors
+    }
+
+    /// The name this function is emitted with in the generated output
+    pub(crate) fn emitted_name(&self) -> String {
+        match self.resolved_function {
+            Some(ref sig) => sig.name.clone(),
+            None => format!("Unresolved_{}", self.selector),
+        }
+    }
+
+    /// The key used to order functions in the generated output. Functions are ordered
+    /// alphabetically by their emitted name, using the resolved signature (for overloads) and
+    /// the selector (for unresolved names) as tie-breakers.
+    fn output_order_key(&self) -> (String, String, String, String) {
+        let name = self.emitted_name();
+        (
+            name.to_lowercase(),
+            name,
+            self.resolved_function.as_ref().map(|sig| sig.signature.clone()).unwrap_or_default(),
+            self.selector.clone(),
+        )
+    }
+}
+
+/// Sorts analyzed functions into the deterministic order used by all generated output, so that
+/// decompiling the same bytecode twice always yields byte-identical results.
+pub(crate) fn sort_analyzed_functions(functions: &mut [AnalyzedFunction]) {
+    functions.sort_by_cached_key(|f| f.output_order_key());
 }

--- a/crates/decompile/src/utils/postprocessors/variable.rs
+++ b/crates/decompile/src/utils/postprocessors/variable.rs
@@ -40,14 +40,22 @@ pub(crate) fn variable_postprocessor(
     );
     if !preserves_operands {
         statement.visit_exprs_mut(&mut |expr| {
-            let replacement = state.variable_map.iter().find_map(|(variable, value)| {
-                let is_trivial = matches!(
-                    value,
-                    Expr::Identifier(_) | Expr::Literal(_) | Expr::Bool(_) | Expr::StringLiteral(_)
-                );
-                (!is_trivial && value == expr && assignment_target.as_ref() != Some(variable))
-                    .then_some(variable)
-            });
+            // the smallest matching variable is used, since map iteration order is not stable
+            let replacement = state
+                .variable_map
+                .iter()
+                .filter_map(|(variable, value)| {
+                    let is_trivial = matches!(
+                        value,
+                        Expr::Identifier(_) |
+                            Expr::Literal(_) |
+                            Expr::Bool(_) |
+                            Expr::StringLiteral(_)
+                    );
+                    (!is_trivial && value == expr && assignment_target.as_ref() != Some(variable))
+                        .then_some(variable)
+                })
+                .min_by_key(|variable| variable.render());
             if let Some(variable) = replacement {
                 *expr = variable.clone();
             }


### PR DESCRIPTION
## What changed? Why?

Decompiled output was assembled in the iteration order of the symbolic execution results, which live in a randomly seeded `HashMap`. Decompiling the same bytecode twice with the same version therefore produced functionally identical but textually different output — functions (and Yul cases) appeared in an arbitrary order on every run, which makes diffing, caching and snapshotting decompiler output impossible.

Analyzed functions are now sorted once, before any output is constructed, so the Solidity source, the Yul source and the ABI all share the same deterministic order. Functions are ordered alphabetically (case-insensitively) by their emitted name, with the resolved signature (for overloads) and then the selector (for unresolved names) as tie-breakers.

While sorting the functions, a few adjacent map-order dependent collections that defeat the same goal were also made deterministic:

- event/error declarations in the Solidity output are emitted in a sorted order instead of `HashMap` order,
- per-function event/error selectors are iterated in sorted order when building the ABI,
- the variable-substitution pass and public-getter naming now pick the smallest matching candidate instead of an arbitrary one.

Function bodies, signatures and semantics are untouched — this only affects the order in which existing output is emitted. The `fallback`/`default` entry points are still emitted separately and remain valid.

## Notes to reviewers

- `crates/decompile/src/interfaces/function.rs`: adds `emitted_name()` and `sort_analyzed_functions()`, the single ordering used by all output paths. Event and error selectors are stored in a `BTreeSet`, so they are already in a deterministic order everywhere they are read.
- `crates/decompile/src/core/mod.rs`: sorts the analyzed functions after signature matching and before postprocessing/output construction.
- `crates/decompile/src/core/out/source.rs`: uses the shared emitted name, and returns event/error declarations as a sorted `Vec<Declaration>` instead of a `HashMap` of nested tuples. Each `Declaration` carries its unresolved name, resolved name and full declaration line, which also removes the `split('(')` dance the rename pass used to recover the resolved name.
- `crates/decompile/src/core/out/abi.rs`: uses the shared emitted name and the ordered event/error selector sets. Note this also makes the existing (pre-existing) name-collision behaviour deterministic — when two functions share a name, the ABI keeps the last one in sorted order rather than an arbitrary one.
- `crates/decompile/src/core/postprocess.rs`, `crates/decompile/src/utils/postprocessors/variable.rs`: deterministic candidate selection where a `HashMap` was previously picked from arbitrarily.

## How has it been tested?

- New unit tests in `crates/decompile/src/core/out/source.rs` build the same function set in three different insertion orders (original, reversed, rotated) and assert that the generated Solidity and Yul output is byte-identical, that functions/cases are emitted alphabetically, that each body stays attached to its own header, and that the fallback (`fallback() external payable`) and `default` entry points are still emitted correctly. Additional tests cover overload ordering by signature and sorted event/error declarations.
- Additional unit tests cover case-insensitive name ordering (`names_are_sorted_case_insensitively`) and the fact that declarations stay deduplicated by their unresolved name (`declarations_are_deduplicated_by_unresolved_name`).
- New integration tests in `crates/core/tests/test_decompile.rs` decompile a local dispatcher fixture (no RPC, no resolving) twice for both the Solidity and Yul paths and assert byte-identical output plus alphabetical ordering.
- `cargo test -p heimdall-decompiler --lib` — 79 passed, 0 failed.
- `cargo test -p heimdall-core --test test_decompile deterministic` — 2 passed, 0 failed.
- `cargo +nightly fmt --all` and `cargo clippy --all-features` (only the pre-existing `redundant_guards` warning in `utils/postprocessors/control_flow.rs` remains).

Remaining known nondeterminism: signature/event/error resolution goes over the network, so output can still differ between runs when resolution is enabled and the upstream signature database changes or a lookup fails. Everything downstream of resolution is deterministic for a fixed set of resolved signatures.

