### PR TITLE
docs: add academic citation for semantic-preserving obfuscation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Heimdall has been cited in the following academic papers & theses:
 - Chen, Z., Beillahi, S. M., Barahimi, P., Minwalla, C., Du, H., Veneris, A., & Long, F. (2025). *Secure smart contract with control flow integrity*. arXiv. https://doi.org/10.48550/arXiv.2504.05509
 - Darwish, M. (2024). *From bytecode to safety: Decompiling smart contracts for vulnerability analysis* [Bachelor’s thesis, Linnaeus University]. DiVA Portal. https://urn.kb.se/resolve?urn=urn:nbn:se:lnu:diva-129903
 - De Rosa, P., Felber, P., & Schiavoni, V. (2026). Seeing through EVM bytecode obfuscation. *IEEE Access*, *14*, 25515–25536. https://ieeexplore.ieee.org/document/11373339
+- Dai, N. D., & Tuan, L. M. (2026). *Towards Semantic-Preserving Obfuscation for Analysis-Resistant EVM Bytecode*. Journal of Science and Technology on Information security. https://isj.vn/index.php/journal_STIS/article/view/6410
 - Forissier, T. (2024). *EVeilM: EVM bytecode obfuscation* [Master’s thesis, KTH Royal Institute of Technology]. DiVA Portal. https://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-359674
 - Gkioka, M. (2025). *Domain transfer via decompilation: Enhancing code LLMs’ performance for blockchain applications* [Master’s thesis, National and Kapodistrian University of Athens]. Pergamos. https://pergamos.lib.uoa.gr/uoa/dl/object/5296079
 - Lagouvardos, S., Bollanos, Y., Debono, M., Grech, N. & Smaragdakis, Y. (2025). *Precise static identification of Ethereum storage variables*. arXiv. https://doi.org/10.48550/arXiv.2503.20690


### PR DESCRIPTION
## What changed? Why?

Adds the academic citation for *Towards Semantic-Preserving Obfuscation for Analysis-Resistant EVM Bytecode* to `README.md`. The paper explicitly cites heimdall-rs during its EVM bytecode analysis process and includes the project URL.

Paper: https://isj.vn/index.php/journal_STIS/article/view/6410

## Notes to reviewers

- `README.md`: adds one bibliography entry only.
- No code, runtime behavior, or dependencies change.

## How has it been tested?

- Verified the cited paper PDF identifies heimdall-rs in its bytecode analysis process.
- CI passed: workspace dependency check, formatting, clippy, build, doctests, Ubuntu and macOS tests, coverage, and benchmark.